### PR TITLE
Force stale reads on /catalog/services

### DIFF
--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -90,6 +90,8 @@ func (s *HTTPServer) CatalogServices(resp http.ResponseWriter, req *http.Request
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
 	}
+	// special criteo behavior: no non-stale read is allowed on /catalog/services
+	args.QueryOptions.AllowStale = true
 
 	var out structs.IndexedServices
 	defer setMeta(resp, &out.QueryMeta)


### PR DESCRIPTION
This will mitigate the effect mentionned in prometheus/prometheus#3711.

Our observation is prometheus doing query continously on
/catalog/services endpoint without stale request. This patch is simply a
mitigation waiting for a better implementation client side.

At this point, in criteo, there is no valid use case to get a consistent
list of services.

Change-Id: If7faea17cf6dc4c621615330d4fd1ead0ea3b889