### PR TITLE
Use target service name instead of ID as connect proxy service name

### DIFF
--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -661,7 +661,7 @@ func (l *State) AddProxy(proxy *structs.ConnectManagedProxy, token,
 	svc := &structs.NodeService{
 		Kind:             structs.ServiceKindConnectProxy,
 		ID:               target.ID + "-proxy",
-		Service:          target.ID + "-proxy",
+		Service:          target.Service + "-proxy",
 		ProxyDestination: target.Service,
 		Address:          cfg.BindAddress,
 		Port:             cfg.BindPort,


### PR DESCRIPTION
Apply ACL patch for Consul Connect