### PR TITLE
Allow to rename nodes with IDs

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -350,6 +350,21 @@ func (s *Store) EnsureNode(idx uint64, node *structs.Node) error {
 	return nil
 }
 
+func (s *Store) ensureNoNodeWithSimilarNameTxn(tx *memdb.Txn, node *structs.Node) error {
+	// Retrieve all of the nodes
+	enodes, err := tx.Get("nodes", "id")
+	if err != nil {
+		return fmt.Errorf("Cannot lookup all nodes: %s", err)
+	}
+	for nodeIt := enodes.Next(); nodeIt != nil; nodeIt = enodes.Next() {
+		enode := nodeIt.(*structs.Node)
+		if strings.EqualFold(node.Node, enode.Node) && node.ID != enode.ID {
+			return fmt.Errorf("Node name %s is reserved by node %s with name %s", node.Node, enode.ID, enode.Node)
+		}
+	}
+	return nil
+}
+
 // ensureNodeTxn is the inner function called to actually create a node
 // registration or modify an existing one in the state store. It allows
 // passing in a memdb transaction so it may be part of a larger txn.
@@ -365,11 +380,28 @@ func (s *Store) ensureNodeTxn(tx *memdb.Txn, idx uint64, node *structs.Node) err
 		if existing != nil {
 			n = existing.(*structs.Node)
 			if n.Node != node.Node {
-				return fmt.Errorf("node ID %q for node %q aliases existing node %q",
-					node.ID, node.Node, n.Node)
+				// Lets first get all nodes and check whether name do match
+				dupNameError := s.ensureNoNodeWithSimilarNameTxn(tx, node)
+				if dupNameError != nil {
+					return fmt.Errorf("Error while renaming Node ID: %q: %s", node.ID, dupNameError)
+				}
+				// We are actually renaming a node, remove its reference first
+				err := s.deleteNodeTxn(tx, idx, n.Node)
+				if err != nil {
+					return fmt.Errorf("Error while renaming Node ID: %q from %s to %s",
+						node.ID, n.Node, node.Node)
+				}
+			}
+		} else {
+			// We are adding a node with an ID, ensure name is not already taken by another node
+			dupNameError := s.ensureNoNodeWithSimilarNameTxn(tx, node)
+			if dupNameError != nil {
+				return fmt.Errorf("Error while renaming Node ID: %q: %s", node.ID, dupNameError)
 			}
 		}
 	}
+	// TODO: else Node.ID == nil should be forbidden in future Consul releases
+	// See https://github.com/hashicorp/consul/pull/3983 for context
 
 	// Check for an existing node by name to support nodes with no IDs.
 	if n == nil {
@@ -377,9 +409,13 @@ func (s *Store) ensureNodeTxn(tx *memdb.Txn, idx uint64, node *structs.Node) err
 		if err != nil {
 			return fmt.Errorf("node name lookup failed: %s", err)
 		}
+
 		if existing != nil {
 			n = existing.(*structs.Node)
 		}
+		// WARNING, for compatibility reasons with tests, we do not check
+		// for case insensitive matches, which may lead to DB corruption
+		// See https://github.com/hashicorp/consul/pull/3983 for context
 	}
 
 	// Get the indexes.

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -392,13 +392,9 @@ func (s *Store) ensureNodeTxn(tx *memdb.Txn, idx uint64, node *structs.Node) err
 						node.ID, n.Node, node.Node)
 				}
 			}
-		} else {
-			// We are adding a node with an ID, ensure name is not already taken by another node
-			dupNameError := s.ensureNoNodeWithSimilarNameTxn(tx, node)
-			if dupNameError != nil {
-				return fmt.Errorf("Error while renaming Node ID: %q: %s", node.ID, dupNameError)
-			}
 		}
+		// TODO: a else statement is missing here to check we are not stealing
+		// a similar case-insensitive name
 	}
 	// TODO: else Node.ID == nil should be forbidden in future Consul releases
 	// See https://github.com/hashicorp/consul/pull/3983 for context

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -401,6 +401,32 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 	}()
 }
 
+func deprecatedEnsureNodeWithoutIDCanRegister(t *testing.T, s *Store, nodeName string, txIdx uint64) {
+	// All the following is deprecated, and should be removed in future Consul versions
+	in := &structs.Node{
+		Node:    nodeName,
+		Address: "1.1.1.9",
+	}
+	if err := s.EnsureNode(txIdx, in); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	idx, out, err := s.GetNode(nodeName)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if idx != txIdx {
+		t.Fatalf("index should be %q, was: %q", txIdx, idx)
+	}
+	if out.Node != nodeName {
+		t.Fatalf("unexpected result out = %q, nodeName supposed to be %s", out, nodeName)
+	}
+}
+
+func TestStateStore_EnsureNodeDeprecated(t *testing.T) {
+	s := testStateStore(t)
+	deprecatedEnsureNodeWithoutIDCanRegister(t, s, "node-without-id", 1)
+}
+
 func TestStateStore_EnsureNode(t *testing.T) {
 	s := testStateStore(t)
 
@@ -482,13 +508,167 @@ func TestStateStore_EnsureNode(t *testing.T) {
 
 	// Now try to add another node with the same ID
 	in = &structs.Node{
-		Node:    "nope",
+		Node:    "node1-renamed",
 		ID:      types.NodeID("cda916bc-a357-4a19-b886-59419fcee50c"),
-		Address: "1.2.3.4",
+		Address: "1.1.1.2",
 	}
-	err = s.EnsureNode(5, in)
-	if err == nil || !strings.Contains(err.Error(), "aliases existing node") {
-		t.Fatalf("err: %v", err)
+	if err := s.EnsureNode(6, in); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Retrieve the node
+	idx, out, err = s.GetNode("node1")
+	if out != nil {
+		t.Fatalf("Node should not exist anymore: %q", out)
+	}
+
+	idx, out, err = s.GetNode("node1-renamed")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if out == nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Node and indexes were updated
+	if out.CreateIndex != 1 || out.ModifyIndex != 6 || out.Address != "1.1.1.2" || out.Node != "node1-renamed" {
+		t.Fatalf("bad: %#v", out)
+	}
+	if idx != 6 {
+		t.Fatalf("bad index: %d", idx)
+	}
+
+	newNodeID := types.NodeID("d0347693-65cc-4d9f-a6e0-5025b2e6513f")
+
+	// Adding another node with same name should fail
+	in = &structs.Node{
+		Node:    "node1-renamed",
+		ID:      newNodeID,
+		Address: "1.1.1.7",
+	}
+	if err := s.EnsureNode(8, in); err == nil {
+		t.Fatalf("There should be an error since node1-renamed already exists")
+	}
+
+	// Adding another node with same name but different case should fail
+	in = &structs.Node{
+		Node:    "Node1-RENAMED",
+		ID:      newNodeID,
+		Address: "1.1.1.7",
+	}
+	if err := s.EnsureNode(8, in); err == nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Lets add another valid node now
+	in = &structs.Node{
+		Node:    "Node1bis",
+		ID:      newNodeID,
+		Address: "1.1.1.7",
+	}
+	if err := s.EnsureNode(9, in); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Retrieve the node
+	idx, out, err = s.GetNode("Node1bis")
+	if out == nil {
+		t.Fatalf("Node should exist, but was null")
+	}
+
+	// Renaming should fail
+	in = &structs.Node{
+		Node:    "Node1bis",
+		ID:      newNodeID,
+		Address: "1.1.1.7",
+	}
+	if err := s.EnsureNode(9, in); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	idx, out, err = s.GetNode("Node1bis")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Node and indexes were updated
+	if out.ID != newNodeID || out.CreateIndex != 9 || out.ModifyIndex != 9 || out.Address != "1.1.1.7" || out.Node != "Node1bis" {
+		t.Fatalf("bad: %#v", out)
+	}
+	if idx != 9 {
+		t.Fatalf("bad index: %d", idx)
+	}
+
+	// Renaming to same value as first node should fail as well
+	// Adding another node with same name but different case should fail
+	in = &structs.Node{
+		Node:    "node1-renamed",
+		ID:      newNodeID,
+		Address: "1.1.1.7",
+	}
+	if err := s.EnsureNode(10, in); err == nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// It should fail also with different case
+	in = &structs.Node{
+		Node:    "Node1-Renamed",
+		ID:      newNodeID,
+		Address: "1.1.1.7",
+	}
+	if err := s.EnsureNode(10, in); err == nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// But should work if names are different
+	in = &structs.Node{
+		Node:    "Node1-Renamed2",
+		ID:      newNodeID,
+		Address: "1.1.1.7",
+	}
+	if err := s.EnsureNode(11, in); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	idx, out, err = s.GetNode("Node1-Renamed2")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Node and indexes were updated
+	if out.ID != newNodeID || out.CreateIndex != 9 || out.ModifyIndex != 11 || out.Address != "1.1.1.7" || out.Node != "Node1-Renamed2" {
+		t.Fatalf("bad: %#v", out)
+	}
+	if idx != 11 {
+		t.Fatalf("bad index: %d", idx)
+	}
+
+	// All the remaining tests are deprecated, please remove them on next Consul major release
+	// See https://github.com/hashicorp/consul/pull/3983 for context
+
+	// Deprecated behavior is following
+	deprecatedEnsureNodeWithoutIDCanRegister(t, s, "new-node-without-id", 12)
+
+	// Deprecated, but should work as well
+	deprecatedEnsureNodeWithoutIDCanRegister(t, s, "new-node-without-id", 13)
+
+	// All of this is deprecated as well, should be removed
+	in = &structs.Node{
+		Node:    "Node1-Renamed2",
+		Address: "1.1.1.66",
+	}
+	if err := s.EnsureNode(14, in); err != nil {
+		t.Fatalf("[DEPRECATED] it should work, err:= %q", err)
+	}
+	idx, out, err = s.GetNode("Node1-Renamed2")
+	if err != nil {
+		t.Fatalf("[DEPRECATED] err: %s", err)
+	}
+	if out.CreateIndex != 9 {
+		t.Fatalf("[DEPRECATED] We expected to modify node previously added, but add index = %d for node %q", out.CreateIndex, out)
+	}
+	if out.Address != "1.1.1.66" || out.ModifyIndex != 14 {
+		t.Fatalf("[DEPRECATED] Node with newNodeID should have been updated, but was: %d with content := %q", out.CreateIndex, out)
 	}
 }
 

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -115,7 +115,7 @@ func TestStateStore_ensureNoNodeWithSimilarNameTxn(t *testing.T) {
 		t.Fatalf("Should return an error since another name with similar name exists")
 	}
 	if err := s.ensureNoNodeWithSimilarNameTxn(tx, node, true); err != nil {
-		t.Fatalf("Should return an error since another name with similar name exists")
+		t.Fatalf("Should not clash with another similar node name without ID, err:=%q", err)
 	}
 
 }

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -64,8 +64,24 @@ func TestStateStore_EnsureRegistration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("got err %s want nil", err)
 		}
+		if out2 == nil {
+			t.Fatalf("out2 should not be nil")
+		}
 		if got, want := out, out2; !verify.Values(t, "GetNodeID", got, want) {
 			t.FailNow()
+		}
+		_, out3, err := s.GetNodeID(types.NodeID("wrongId"))
+		if err == nil || out3 != nil || !strings.Contains(err.Error(), "node lookup by ID failed: UUID must be 36 characters") {
+			t.Fatalf("want an error, nil value, err:=%q ; out3:=%q", err.Error(), out3)
+		}
+		_, out3, err = s.GetNodeID(types.NodeID("0123456789abcdefghijklmnopqrstuvwxyz"))
+		if err == nil || out3 != nil || !strings.Contains(err.Error(), "node lookup by ID failed: wrong UUID format") {
+			t.Fatalf("want an error, nil value, err:=%q ; out3:=%q", err, out3)
+		}
+
+		_, out3, err = s.GetNodeID(types.NodeID("00a916bc-a357-4a19-b886-59419fcee50Z"))
+		if err == nil || out3 != nil || !strings.Contains(err.Error(), "node lookup by ID failed: encoding/hex: invalid byte") {
+			t.Fatalf("want an error, nil value, err:=%q ; out3:=%q", err, out3)
 		}
 	}
 	verifyNode()

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -28,16 +28,16 @@ func makeRandomNodeID(t *testing.T) types.NodeID {
 func TestStateStore_GetNodeID(t *testing.T) {
 	s := testStateStore(t)
 	_, out, err := s.GetNodeID(types.NodeID("wrongId"))
-	if err == nil || out != nil || !strings.Contains(err.Error(), "node lookup by ID failed: UUID must be 36 characters") {
+	if err == nil || out != nil || !strings.Contains(err.Error(), "node lookup by ID failed, wrong UUID") {
 		t.Fatalf("want an error, nil value, err:=%q ; out:=%q", err.Error(), out)
 	}
 	_, out, err = s.GetNodeID(types.NodeID("0123456789abcdefghijklmnopqrstuvwxyz"))
-	if err == nil || out != nil || !strings.Contains(err.Error(), "node lookup by ID failed: wrong UUID format") {
+	if err == nil || out != nil || !strings.Contains(err.Error(), "node lookup by ID failed, wrong UUID") {
 		t.Fatalf("want an error, nil value, err:=%q ; out:=%q", err, out)
 	}
 
 	_, out, err = s.GetNodeID(types.NodeID("00a916bc-a357-4a19-b886-59419fcee50Z"))
-	if err == nil || out != nil || !strings.Contains(err.Error(), "node lookup by ID failed: encoding/hex: invalid byte") {
+	if err == nil || out != nil || !strings.Contains(err.Error(), "node lookup by ID failed, wrong UUID") {
 		t.Fatalf("want an error, nil value, err:=%q ; out:=%q", err, out)
 	}
 


### PR DESCRIPTION
See https://github.com/hashicorp/consul/pull/4415 for full context

------------
This change allow to rename any well behaving recent agent with an
ID to be renamed safely, ie: without taking the name of another one
with case insensitive comparison.