### PR TITLE
api: non-connect endpoints give downstream connect informations

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3124,6 +3124,10 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig, snap map[structs.CheckI
 		// Remove sidecar from NodeService now it's done it's job it's just a config
 		// syntax sugar and shouldn't be persisted in local or server state.
 		ns.Connect.SidecarService = nil
+		ns.Proxy.LocalServicePort = sidecar.Port
+		ns.Proxy.LocalServiceAddress = sidecar.Address
+		ns.Proxy.DestinationServiceID = sidecar.ID
+		ns.Proxy.DestinationServiceName = sidecar.Service
 
 		sid := ns.CompoundServiceID()
 		err = a.addServiceLocked(&addServiceRequest{

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -981,6 +981,10 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 		// persist it in the actual state/catalog. SidecarService is meant to be a
 		// registration syntax sugar so don't propagate it any further.
 		ns.Connect.SidecarService = nil
+		ns.Proxy.LocalServicePort = sidecar.Port
+		ns.Proxy.LocalServiceAddress = sidecar.Address
+		ns.Proxy.DestinationServiceID = sidecar.ID
+		ns.Proxy.DestinationServiceName = sidecar.Service
 	}
 
 	// Add the service.


### PR DESCRIPTION
This is a blind attempt to fix the issue I described here: https://github.com/hashicorp/consul/issues/9744.

While waiting for a feedback regarding the semantic (naming of fields, etc.) I propose to introduce this.

The tests seems a bit in a bad state, I didn't succeed to have tests passing even when I'm on the criteo/1.9.3-criteo branch, so I didn't bother fixing them here.