### PR TITLE
Apply 1.12.5-criteo8 changes onto 1.12.9

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3307,6 +3307,12 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig, snap map[structs.CheckI
 		// Remove sidecar from NodeService now it's done it's job it's just a config
 		// syntax sugar and shouldn't be persisted in local or server state.
 		ns.Connect.SidecarService = nil
+		if sidecar != nil {
+			ns.Proxy.LocalServicePort = sidecar.Port
+			ns.Proxy.LocalServiceAddress = sidecar.Address
+			ns.Proxy.DestinationServiceID = sidecar.ID
+			ns.Proxy.DestinationServiceName = sidecar.Service
+		}
 
 		sid := ns.CompoundServiceID()
 		err = a.addServiceLocked(addServiceLockedRequest{

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1180,6 +1180,12 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 		// persist it in the actual state/catalog. SidecarService is meant to be a
 		// registration syntax sugar so don't propagate it any further.
 		ns.Connect.SidecarService = nil
+		if sidecar != nil {
+		   ns.Proxy.LocalServicePort = sidecar.Port
+		   ns.Proxy.LocalServiceAddress = sidecar.Address
+		   ns.Proxy.DestinationServiceID = sidecar.ID
+		   ns.Proxy.DestinationServiceName = sidecar.Service
+		}
 	}
 
 	// Add the service.

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3630,10 +3630,10 @@ func testAgent_RegisterService_TranslateKeys(t *testing.T, extraHCL string) {
 				Weights:           &structs.Weights{Passing: 16, Warning: 0},
 				Kind:              structs.ServiceKindConnectProxy,
 				Proxy: structs.ConnectProxyConfig{
-					DestinationServiceName: "web",
-					DestinationServiceID:   "web",
-					LocalServiceAddress:    tt.ip,
-					LocalServicePort:       1234,
+					DestinationServiceName: "test-proxy",
+					DestinationServiceID:   "test-sidecar-proxy",
+					LocalServiceAddress:    "",
+					LocalServicePort:       8001,
 					Config: map[string]interface{}{
 						"destination_type": "proxy.config is 'opaque' so should not get translated",
 					},

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3674,7 +3674,7 @@ func testAgent_RegisterService_TranslateKeys(t *testing.T, extraHCL string) {
 				TaggedAddresses:            map[string]structs.ServiceAddress{},
 				Port:                       8001,
 				EnableTagOverride:          true,
-				Weights:                    &structs.Weights{Passing: 1, Warning: 1},
+				Weights:                    &structs.Weights{Passing: 16, Warning: 0},
 				LocallyRegisteredAsSidecar: true,
 				Proxy: structs.ConnectProxyConfig{
 					DestinationServiceName: "test",

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -224,7 +224,13 @@ func (c *ConsulProvider) GenerateIntermediateCSR() (string, string, error) {
 		return "", "", err
 	}
 
-	csr, err := connect.CreateCACSR(c.spiffeID, signer)
+	uid, err := connect.CompactUID()
+	if err != nil {
+		return "", "", err
+	}
+	cn := connect.CACN("consul", uid, c.clusterID, c.isPrimary)
+
+	csr, err := connect.CreateCACSR(c.spiffeID, cn, signer)
 	if err != nil {
 		return "", "", err
 	}

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -449,6 +449,9 @@ func testSignIntermediateCrossDC(t *testing.T, provider1, provider2 Provider) {
 	// Sign the CSR with provider1.
 	intermediatePEM, err := provider1.SignIntermediate(csr)
 	require.NoError(t, err)
+	intermediateCert, err := connect.ParseCert(intermediatePEM)
+	require.NoError(t, err)
+	require.NotEmpty(t, intermediateCert.Subject.CommonName)
 	root, err := provider1.GenerateRoot()
 	require.NoError(t, err)
 	rootPEM := root.PEM
@@ -475,6 +478,8 @@ func testSignIntermediateCrossDC(t *testing.T, provider1, provider2 Provider) {
 	require.NoError(t, err)
 	requireNotEncoded(t, cert.SubjectKeyId)
 	requireNotEncoded(t, cert.AuthorityKeyId)
+	require.NotEmpty(t, cert.Issuer.CommonName)
+	require.Equal(t, cert.Issuer.CommonName, intermediateCert.Subject.CommonName)
 
 	// Check that the leaf signed by the new cert can be verified using the
 	// returned cert chain (signed intermediate + remote root).

--- a/agent/connect/csr.go
+++ b/agent/connect/csr.go
@@ -90,13 +90,31 @@ func CreateCSR(uri CertURI, privateKey crypto.Signer,
 
 // CreateCSR returns a CA CSR to sign the given service along with the PEM-encoded
 // private key for this certificate.
-func CreateCACSR(uri CertURI, privateKey crypto.Signer) (string, error) {
+func CreateCACSR(uri CertURI, commonName string, privateKey crypto.Signer) (string, error) {
 	ext, err := CreateCAExtension()
 	if err != nil {
 		return "", err
 	}
+        template := &x509.CertificateRequest{
+                URIs:               []*url.URL{uri.URI()},
+                SignatureAlgorithm: SigAlgoForKey(privateKey),
+                ExtraExtensions:    []pkix.Extension{ext},
+		Subject:            pkix.Name{CommonName: commonName},
+        }
 
-	return CreateCSR(uri, privateKey, nil, nil, ext)
+        // Create the CSR itself
+        var csrBuf bytes.Buffer
+        bs, err := x509.CreateCertificateRequest(rand.Reader, template, privateKey)
+        if err != nil {
+                return "", err
+        }
+
+        err = pem.Encode(&csrBuf, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: bs})
+        if err != nil {
+                return "", err
+        }
+
+        return csrBuf.String(), nil
 }
 
 // CreateCAExtension creates a pkix.Extension for the x509 Basic Constraints

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -417,7 +417,7 @@ func TestACLEndpoint_TokenClone(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	endpoint := ACL{srv: srv}
+	endpoint := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	t.Run("normal", func(t *testing.T) {
 		req := structs.ACLTokenSetRequest{
@@ -478,7 +478,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 	}, false)
 	waitForLeaderEstablishment(t, srv)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	var tokenID string
 
@@ -701,7 +701,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 	})
 
 	t.Run("Update auth method linked token and let the SecretID and AuthMethod be defaulted", func(t *testing.T) {
-		acl := ACL{srv: srv}
+		acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 		testSessionID := testauth.StartSession()
 		defer testauth.ResetSession(testSessionID)
@@ -1244,7 +1244,7 @@ func TestACLEndpoint_TokenSet_CustomID(t *testing.T) {
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	// No Create Arg
 	t.Run("no create arg", func(t *testing.T) {
@@ -1513,7 +1513,7 @@ func TestACLEndpoint_TokenSet_anon(t *testing.T) {
 	policy, err := upsertTestPolicy(codec, TestDefaultInitialManagementToken, "dc1")
 	require.NoError(t, err)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	// Assign the policies to a token
 	tokenUpsertReq := structs.ACLTokenSetRequest{
@@ -1569,8 +1569,8 @@ func TestACLEndpoint_TokenDelete(t *testing.T) {
 	// Ensure s2 is authoritative.
 	waitForNewACLReplication(t, s2, structs.ACLReplicateTokens, 1, 1, 0)
 
-	acl := ACL{srv: s1}
-	acl2 := ACL{srv: s2}
+	acl := ACL{srv: s1, logger: testutil.Logger(t)}
+	acl2 := ACL{srv: s2, logger: testutil.Logger(t)}
 
 	existingToken, err := upsertTestToken(codec, TestDefaultInitialManagementToken, "dc1", nil)
 	require.NoError(t, err)
@@ -2015,7 +2015,7 @@ func TestACLEndpoint_PolicySet(t *testing.T) {
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	var policyID string
 
@@ -2132,7 +2132,7 @@ func TestACLEndpoint_PolicySet_globalManagement(t *testing.T) {
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	// Can't change the rules
 	{
@@ -2191,7 +2191,7 @@ func TestACLEndpoint_PolicyDelete(t *testing.T) {
 	existingPolicy, err := upsertTestPolicy(codec, TestDefaultInitialManagementToken, "dc1")
 	require.NoError(t, err)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	req := structs.ACLPolicyDeleteRequest{
 		Datacenter:   "dc1",
@@ -2249,7 +2249,7 @@ func TestACLEndpoint_PolicyList(t *testing.T) {
 	p2, err := upsertTestPolicy(codec, TestDefaultInitialManagementToken, "dc1")
 	require.NoError(t, err)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	req := structs.ACLPolicyListRequest{
 		Datacenter:   "dc1",
@@ -2285,7 +2285,7 @@ func TestACLEndpoint_PolicyResolve(t *testing.T) {
 	p2, err := upsertTestPolicy(codec, TestDefaultInitialManagementToken, "dc1")
 	require.NoError(t, err)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	policies := []string{p1.ID, p2.ID}
 
@@ -2389,7 +2389,7 @@ func TestACLEndpoint_RoleSet(t *testing.T) {
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 	var roleID string
 
 	testPolicy1, err := upsertTestPolicy(codec, TestDefaultInitialManagementToken, "dc1")
@@ -2751,7 +2751,7 @@ func TestACLEndpoint_RoleSet_names(t *testing.T) {
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 	testPolicy1, err := upsertTestPolicy(codec, TestDefaultInitialManagementToken, "dc1")
 
 	require.NoError(t, err)
@@ -2836,7 +2836,7 @@ func TestACLEndpoint_RoleDelete(t *testing.T) {
 
 	require.NoError(t, err)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	req := structs.ACLRoleDeleteRequest{
 		Datacenter:   "dc1",
@@ -2902,7 +2902,7 @@ func TestACLEndpoint_RoleResolve(t *testing.T) {
 		r2, err := upsertTestRole(codec, TestDefaultInitialManagementToken, "dc1")
 		require.NoError(t, err)
 
-		acl := ACL{srv: srv}
+		acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 		// Assign the roles to a token
 		tokenUpsertReq := structs.ACLTokenSetRequest{
@@ -4311,7 +4311,7 @@ func TestACLEndpoint_Login(t *testing.T) {
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	testSessionID := testauth.StartSession()
 	defer testauth.ResetSession(testSessionID)

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -142,6 +142,14 @@ func (c *Catalog) Register(args *structs.RegisterRequest, reply *struct{}) error
 	}
 
 	_, err = c.srv.raftApply(structs.RegisterRequestType, args)
+
+	// Node creation has no service
+	if args.Service != nil {
+		c.logger.Named("audit").Warn("Service registered ",
+			"ID", args.Service.ID, "name", args.Service.Service,
+			"address", args.Service.Address, "port", args.Service.Port,
+			"metaKeys", args.Service.Meta)
+	}
 	return err
 }
 
@@ -386,6 +394,9 @@ func (c *Catalog) Deregister(args *structs.DeregisterRequest, reply *struct{}) e
 	}
 
 	_, err = c.srv.raftApply(structs.DeregisterRequestType, args)
+
+	c.logger.Named("audit").Warn("Service deregistered ", "ID", args.ServiceID)
+
 	return err
 }
 

--- a/agent/consul/kvs_endpoint.go
+++ b/agent/consul/kvs_endpoint.go
@@ -128,6 +128,15 @@ func (k *KVS) Apply(args *structs.KVSRequest, reply *bool) error {
 	if respBool, ok := resp.(bool); ok {
 		*reply = respBool
 	}
+
+	switch args.Op {
+	case api.KVDelete, api.KVDeleteCAS:
+		k.logger.Named("audit").Warn("K/V entry deleted",
+			"accessorID", authz.AccessorID(), "key", args.DirEnt.Key)
+	case api.KVSet, api.KVCAS:
+		k.logger.Named("audit").Warn("K/V entry set", "accessorID", authz.AccessorID(),
+			"key", args.DirEnt.Key, "value", string(args.DirEnt.Value[:]))
+	}
 	return nil
 }
 

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -753,7 +753,7 @@ func shouldPersistNewRootAndConfig(newActiveRoot *structs.CARoot, oldConfig, new
 	if newConfig == nil {
 		return false
 	}
-	return newConfig.Provider == oldConfig.Provider && reflect.DeepEqual(newConfig.Config, oldConfig.Config)
+	return newConfig.Provider != oldConfig.Provider || !reflect.DeepEqual(newConfig.Config, oldConfig.Config)
 }
 
 func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) {

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -530,6 +530,22 @@ func (c *CAManager) primaryInitialize(provider ca.Provider, conf *structs.CAConf
 		rootUpdateRequired = true
 	}
 
+	// Check if the CA root is already initialized and exit if it is.
+	// Every change to the CA after this initial bootstrapping should
+	// be done through the rotation process, except in some realignment
+	// cases.
+	state := c.delegate.State()
+	_, activeRoot, err := state.CARootActive(nil)
+	if err != nil {
+		return err
+	}
+
+	// Add intermediates from current root if any as intermediates aren't
+	// directly tied to the provider.
+	if activeRoot != nil {
+		rootCA.IntermediateCerts = activeRoot.IntermediateCerts
+	}
+
 	// Add the local leaf signing cert to the rootCA struct. This handles both
 	// upgrades of existing state, and new rootCA.
 	if c.getLeafSigningCertFromRoot(rootCA) != interPEM {
@@ -537,29 +553,25 @@ func (c *CAManager) primaryInitialize(provider ca.Provider, conf *structs.CAConf
 		rootUpdateRequired = true
 	}
 
-	// Check if the CA root is already initialized and exit if it is,
-	// adding on any existing intermediate certs since they aren't directly
-	// tied to the provider.
-	// Every change to the CA after this initial bootstrapping should
-	// be done through the rotation process.
-	state := c.delegate.State()
-	_, activeRoot, err := state.CARootActive(nil)
-	if err != nil {
-		return err
-	}
-	if activeRoot != nil && !rootUpdateRequired {
+	if activeRoot != nil {
 		// This state shouldn't be possible to get into because we update the root and
 		// CA config in the same FSM operation.
 		if activeRoot.ID != rootCA.ID {
 			return fmt.Errorf("stored CA root %q is not the active root (%s)", rootCA.ID, activeRoot.ID)
 		}
 
-		// TODO: why doesn't this c.setCAProvider(provider, activeRoot) ?
-		rootCA.IntermediateCerts = activeRoot.IntermediateCerts
-		c.setCAProvider(provider, rootCA)
+		// If current root in raft misses some changes from generated rootCA, persist those changes.
+		// Don't compare raft index as rootCA has been generated from root PEM.
+		rootCA.RaftIndex = activeRoot.RaftIndex
+		if !reflect.DeepEqual(rootCA, activeRoot) {
+			rootUpdateRequired = true
+		}
 
-		c.logger.Info("initialized primary datacenter CA from existing CARoot with provider", "provider", conf.Provider)
-		return nil
+		if !rootUpdateRequired {
+			c.setCAProvider(provider, activeRoot)
+			c.logger.Info("initialized primary datacenter CA from existing CARoot with provider", "provider", conf.Provider)
+			return nil
+		}
 	}
 
 	if err := c.persistNewRootAndConfig(provider, rootCA, conf); err != nil {

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -1334,8 +1334,8 @@ func TestConnectCA_ConfigurationSet_PersistsRoots(t *testing.T) {
 	s1.Leave()
 	s1.Shutdown()
 
+	var leader *Server
 	retry.Run(t, func(r *retry.R) {
-		var leader *Server
 		for _, s := range []*Server{s2, s3} {
 			if s.IsLeader() {
 				leader = s
@@ -1347,10 +1347,39 @@ func TestConnectCA_ConfigurationSet_PersistsRoots(t *testing.T) {
 		}
 
 		_, newLeaderRoot := getCAProviderWithLock(leader)
+		// Don't check raft id as root was not loaded from raft database but generated.
+		root.RaftIndex = newLeaderRoot.RaftIndex
 		if !reflect.DeepEqual(newLeaderRoot, root) {
 			r.Fatalf("got %v, want %v", newLeaderRoot, root)
 		}
 	})
+
+	_, lastRoot := getCAProviderWithLock(leader)
+
+	// Force another leader change and make sure the root CA values are preserved, including raft index,
+	// to ensure CA initialization doesn't trigger a raft commit.
+	leader.Leave()
+	leader.Shutdown()
+
+	leader = nil
+
+	retry.Run(t, func(r *retry.R) {
+		for _, s := range []*Server{s2, s3} {
+			if s.IsLeader() {
+				leader = s
+				break
+			}
+		}
+		if leader == nil {
+			r.Fatal("no leader")
+		}
+
+		_, newLeaderRoot := getCAProviderWithLock(leader)
+		if !reflect.DeepEqual(newLeaderRoot, lastRoot) {
+			r.Fatalf("got %v, want %v", newLeaderRoot, lastRoot)
+		}
+	})
+
 }
 
 func TestNewCARoot(t *testing.T) {

--- a/agent/rpcclient/health/view.go
+++ b/agent/rpcclient/health/view.go
@@ -56,12 +56,14 @@ func newHealthView(req structs.ServiceSpecificRequest) (*healthView, error) {
 // (IndexedCheckServiceNodes) and update it in place for each event - that
 // involves re-sorting each time etc. though.
 type healthView struct {
-	state  map[string]structs.CheckServiceNode
-	filter filterEvaluator
+	state       map[string]structs.CheckServiceNode
+	filter      filterEvaluator
+	knownLeader bool
 }
 
 // Update implements View
 func (s *healthView) Update(events []*pbsubscribe.Event) error {
+	s.knownLeader = true
 	for _, event := range events {
 		serviceHealth := event.GetServiceHealth()
 		if serviceHealth == nil {
@@ -180,8 +182,10 @@ func (s *healthView) Result(index uint64) interface{} {
 	result := structs.IndexedCheckServiceNodes{
 		Nodes: make(structs.CheckServiceNodes, 0, len(s.state)),
 		QueryMeta: structs.QueryMeta{
-			Index:   index,
-			Backend: structs.QueryBackendStreaming,
+			Index:       index,
+			Backend:     structs.QueryBackendStreaming,
+			KnownLeader: s.knownLeader,
+			LastContact: 0,
 		},
 	}
 	for _, node := range s.state {
@@ -193,6 +197,7 @@ func (s *healthView) Result(index uint64) interface{} {
 }
 
 func (s *healthView) Reset() {
+	s.knownLeader = false
 	s.state = make(map[string]structs.CheckServiceNode)
 }
 

--- a/agent/rpcclient/health/view_test.go
+++ b/agent/rpcclient/health/view_test.go
@@ -102,8 +102,9 @@ func TestHealthView_IntegrationWithStore_WithEmptySnapshot(t *testing.T) {
 	empty := &structs.IndexedCheckServiceNodes{
 		Nodes: structs.CheckServiceNodes{},
 		QueryMeta: structs.QueryMeta{
-			Index:   1,
-			Backend: structs.QueryBackendStreaming,
+			Index:       1,
+			Backend:     structs.QueryBackendStreaming,
+			KnownLeader: true,
 		},
 	}
 
@@ -384,6 +385,7 @@ func TestHealthView_IntegrationWithStore_WithFullSnapshot(t *testing.T) {
 func newExpectedNodes(nodes ...string) *structs.IndexedCheckServiceNodes {
 	result := &structs.IndexedCheckServiceNodes{}
 	result.QueryMeta.Backend = structs.QueryBackendStreaming
+	result.QueryMeta.KnownLeader = true
 	for _, node := range nodes {
 		result.Nodes = append(result.Nodes, structs.CheckServiceNode{
 			Node: &structs.Node{Node: node},

--- a/agent/sidecar_service.go
+++ b/agent/sidecar_service.go
@@ -114,6 +114,12 @@ func (a *Agent) sidecarServiceFromNodeService(ns *structs.NodeService, token str
 		}
 	}
 
+	// Copy service weights if sidecar weights not already defined
+	// .i.e. defined means different from default one
+	if (sidecar.Weights == nil || sidecar.Weights.Passing == 1 && sidecar.Weights.Warning == 1) && ns.Weights != nil {
+		sidecar.Weights = ns.Weights
+	}
+
 	// Allocate port if needed (min and max inclusive).
 	rangeLen := a.config.ConnectSidecarMaxPort - a.config.ConnectSidecarMinPort + 1
 	if sidecar.Port < 1 && a.config.ConnectSidecarMinPort > 0 && rangeLen > 0 {

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -306,6 +306,84 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			},
 			wantToken: "foo",
 		},
+		{
+			name: "connet weights override",
+			sd: &structs.ServiceDefinition{
+				ID:   "web1",
+				Name: "web",
+				Port: 1111,
+				Connect: &structs.ServiceConnect{
+					SidecarService: &structs.ServiceDefinition{
+						Weights: &structs.Weights{Passing: 22, Warning: 12},
+					},
+				},
+				Weights: &structs.Weights{Passing: 21, Warning: 11},
+			},
+			wantNS: &structs.NodeService{
+				EnterpriseMeta:             *structs.DefaultEnterpriseMetaInDefaultPartition(),
+				Kind:                       structs.ServiceKindConnectProxy,
+				ID:                         "web1-sidecar-proxy",
+				Service:                    "web-sidecar-proxy",
+				Port:                       2222,
+				LocallyRegisteredAsSidecar: true,
+				Weights: &structs.Weights{Passing: 22, Warning: 12},
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "web",
+					DestinationServiceID:   "web1",
+					LocalServiceAddress:    "127.0.0.1",
+					LocalServicePort:       1111,
+				},
+			},
+			wantChecks: []*structs.CheckType{
+				{
+					Name:     "Connect Sidecar Listening",
+					TCP:      "127.0.0.1:2222",
+					Interval: 10 * time.Second,
+				},
+				{
+					Name:         "Connect Sidecar Aliasing web1",
+					AliasService: "web1",
+				},
+			},
+		},
+		{
+			name: "connect weights from service",
+			sd: &structs.ServiceDefinition{
+				ID:   "web1",
+				Name: "web",
+				Port: 1111,
+				Connect: &structs.ServiceConnect{
+					SidecarService: &structs.ServiceDefinition{},
+				},
+				Weights: &structs.Weights{Passing: 21, Warning: 11},
+			},
+			wantNS: &structs.NodeService{
+				EnterpriseMeta:             *structs.DefaultEnterpriseMetaInDefaultPartition(),
+				Kind:                       structs.ServiceKindConnectProxy,
+				ID:                         "web1-sidecar-proxy",
+				Service:                    "web-sidecar-proxy",
+				Port:                       2222,
+				LocallyRegisteredAsSidecar: true,
+				Weights: &structs.Weights{Passing: 21, Warning: 11},
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "web",
+					DestinationServiceID:   "web1",
+					LocalServiceAddress:    "127.0.0.1",
+					LocalServicePort:       1111,
+				},
+			},
+			wantChecks: []*structs.CheckType{
+				{
+					Name:     "Connect Sidecar Listening",
+					TCP:      "127.0.0.1:2222",
+					Interval: 10 * time.Second,
+				},
+				{
+					Name:         "Connect Sidecar Aliasing web1",
+					AliasService: "web1",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Apply 1.12.5-criteo8 commits onto 1.12.9 branch.

Manual backports have been removed since they are now included in 1.12.9 branch
This includes the following commits :

- c4995b34a939d9d02387e5e088a802477b38c79d : Refactor client RPC timeouts (#14965)
- ec96a1d4a344f98993ad6f1229d6b86162ed8ed4 : Regenerate test certificates. (#15218)
- 00944e19a4b6650ca8e6d92a772d1124c782f6a0 : Remove unused methods from template


Commit 8b3bdb96bc37c183ca7e5a07d281bbca1a457200 had to be amended to return 3 values instead of two due to changes introduced between 1.12.5 and 1.12.9