### PR TITLE
Rebase 1.12.9 no audit

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3404,6 +3404,12 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig, snap map[structs.CheckI
 		// Remove sidecar from NodeService now it's done it's job it's just a config
 		// syntax sugar and shouldn't be persisted in local or server state.
 		ns.Connect.SidecarService = nil
+		if sidecar != nil {
+			ns.Proxy.LocalServicePort = sidecar.Port
+			ns.Proxy.LocalServiceAddress = sidecar.Address
+			ns.Proxy.DestinationServiceID = sidecar.ID
+			ns.Proxy.DestinationServiceName = sidecar.Service
+		}
 
 		sid := ns.CompoundServiceID()
 		err = a.addServiceLocked(addServiceLockedRequest{

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1188,6 +1188,12 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 		// persist it in the actual state/catalog. SidecarService is meant to be a
 		// registration syntax sugar so don't propagate it any further.
 		ns.Connect.SidecarService = nil
+		if sidecar != nil {
+		   ns.Proxy.LocalServicePort = sidecar.Port
+		   ns.Proxy.LocalServiceAddress = sidecar.Address
+		   ns.Proxy.DestinationServiceID = sidecar.ID
+		   ns.Proxy.DestinationServiceName = sidecar.Service
+		}
 	}
 
 	// Add the service.

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3731,7 +3731,7 @@ func testAgent_RegisterService_TranslateKeys(t *testing.T, extraHCL string) {
 				TaggedAddresses:            map[string]structs.ServiceAddress{},
 				Port:                       8001,
 				EnableTagOverride:          true,
-				Weights:                    &structs.Weights{Passing: 1, Warning: 1},
+				Weights:                    &structs.Weights{Passing: 16, Warning: 0},
 				LocallyRegisteredAsSidecar: true,
 				Proxy: structs.ConnectProxyConfig{
 					DestinationServiceName: "test",

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3687,10 +3687,10 @@ func testAgent_RegisterService_TranslateKeys(t *testing.T, extraHCL string) {
 				Weights:           &structs.Weights{Passing: 16, Warning: 0},
 				Kind:              structs.ServiceKindConnectProxy,
 				Proxy: structs.ConnectProxyConfig{
-					DestinationServiceName: "web",
-					DestinationServiceID:   "web",
-					LocalServiceAddress:    tt.ip,
-					LocalServicePort:       1234,
+					DestinationServiceName: "test-proxy",
+					DestinationServiceID:   "test-sidecar-proxy",
+					LocalServiceAddress:    "",
+					LocalServicePort:       8001,
 					Config: map[string]interface{}{
 						"destination_type": "proxy.config is 'opaque' so should not get translated",
 					},

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -224,7 +224,13 @@ func (c *ConsulProvider) GenerateIntermediateCSR() (string, string, error) {
 		return "", "", err
 	}
 
-	csr, err := connect.CreateCACSR(c.spiffeID, signer)
+	uid, err := connect.CompactUID()
+	if err != nil {
+		return "", "", err
+	}
+	cn := connect.CACN("consul", uid, c.clusterID, c.isPrimary)
+
+	csr, err := connect.CreateCACSR(c.spiffeID, cn, signer)
 	if err != nil {
 		return "", "", err
 	}

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -449,6 +449,9 @@ func testSignIntermediateCrossDC(t *testing.T, provider1, provider2 Provider) {
 	// Sign the CSR with provider1.
 	intermediatePEM, err := provider1.SignIntermediate(csr)
 	require.NoError(t, err)
+	intermediateCert, err := connect.ParseCert(intermediatePEM)
+	require.NoError(t, err)
+	require.NotEmpty(t, intermediateCert.Subject.CommonName)
 	root, err := provider1.GenerateRoot()
 	require.NoError(t, err)
 	rootPEM := root.PEM
@@ -475,6 +478,8 @@ func testSignIntermediateCrossDC(t *testing.T, provider1, provider2 Provider) {
 	require.NoError(t, err)
 	requireNotEncoded(t, cert.SubjectKeyId)
 	requireNotEncoded(t, cert.AuthorityKeyId)
+	require.NotEmpty(t, cert.Issuer.CommonName)
+	require.Equal(t, cert.Issuer.CommonName, intermediateCert.Subject.CommonName)
 
 	// Check that the leaf signed by the new cert can be verified using the
 	// returned cert chain (signed intermediate + remote root).

--- a/agent/connect/csr.go
+++ b/agent/connect/csr.go
@@ -91,13 +91,31 @@ func CreateCSR(uri CertURI, privateKey crypto.Signer,
 
 // CreateCSR returns a CA CSR to sign the given service along with the PEM-encoded
 // private key for this certificate.
-func CreateCACSR(uri CertURI, privateKey crypto.Signer) (string, error) {
+func CreateCACSR(uri CertURI, commonName string, privateKey crypto.Signer) (string, error) {
 	ext, err := CreateCAExtension()
 	if err != nil {
 		return "", err
 	}
+        template := &x509.CertificateRequest{
+                URIs:               []*url.URL{uri.URI()},
+                SignatureAlgorithm: SigAlgoForKey(privateKey),
+                ExtraExtensions:    []pkix.Extension{ext},
+		Subject:            pkix.Name{CommonName: commonName},
+        }
 
-	return CreateCSR(uri, privateKey, nil, nil, ext)
+        // Create the CSR itself
+        var csrBuf bytes.Buffer
+        bs, err := x509.CreateCertificateRequest(rand.Reader, template, privateKey)
+        if err != nil {
+                return "", err
+        }
+
+        err = pem.Encode(&csrBuf, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: bs})
+        if err != nil {
+                return "", err
+        }
+
+        return csrBuf.String(), nil
 }
 
 // CreateCAExtension creates a pkix.Extension for the x509 Basic Constraints

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -754,7 +754,7 @@ func shouldPersistNewRootAndConfig(newActiveRoot *structs.CARoot, oldConfig, new
 	if newConfig == nil {
 		return false
 	}
-	return newConfig.Provider == oldConfig.Provider && reflect.DeepEqual(newConfig.Config, oldConfig.Config)
+	return newConfig.Provider != oldConfig.Provider || !reflect.DeepEqual(newConfig.Config, oldConfig.Config)
 }
 
 func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) {

--- a/agent/rpcclient/health/view_test.go
+++ b/agent/rpcclient/health/view_test.go
@@ -114,8 +114,9 @@ func testHealthView_IntegrationWithStore_WithEmptySnapshot(t *testing.T, peerNam
 	empty := &structs.IndexedCheckServiceNodes{
 		Nodes: structs.CheckServiceNodes{},
 		QueryMeta: structs.QueryMeta{
-			Index:   1,
-			Backend: structs.QueryBackendStreaming,
+			Index:       1,
+			Backend:     structs.QueryBackendStreaming,
+			KnownLeader: true,
 		},
 	}
 
@@ -423,6 +424,7 @@ func testHealthView_IntegrationWithStore_WithFullSnapshot(t *testing.T, peerName
 func newExpectedNodesInPeer(peerName string, nodes ...string) *structs.IndexedCheckServiceNodes {
 	result := &structs.IndexedCheckServiceNodes{}
 	result.QueryMeta.Backend = structs.QueryBackendStreaming
+	result.QueryMeta.KnownLeader = true
 	for _, node := range nodes {
 		result.Nodes = append(result.Nodes, structs.CheckServiceNode{
 			Node: &structs.Node{

--- a/agent/sidecar_service.go
+++ b/agent/sidecar_service.go
@@ -122,6 +122,12 @@ func sidecarServiceFromNodeService(ns *structs.NodeService, token string) (*stru
 		}
 	}
 
+	// Copy service weights if sidecar weights not already defined
+	// .i.e. defined means different from default one
+	if (sidecar.Weights == nil || sidecar.Weights.Passing == 1 && sidecar.Weights.Warning == 1) && ns.Weights != nil {
+		sidecar.Weights = ns.Weights
+	}
+	
 	// Setup checks
 	checks, err := ns.Connect.SidecarService.CheckTypes()
 	if err != nil {


### PR DESCRIPTION
Port some 1.12.x fixes to latest 1.13.x

Do not port the 7c5f907408e15cf0b16dc9a904c44ee5bf0c57ff which allowed us to change the root CA