### PR TITLE
Rebase 1.12.9 audit

### DIFF
--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -418,7 +418,7 @@ func TestACLEndpoint_TokenClone(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	endpoint := ACL{srv: srv}
+	endpoint := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	t.Run("normal", func(t *testing.T) {
 		req := structs.ACLTokenSetRequest{
@@ -479,7 +479,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 	}, false)
 	waitForLeaderEstablishment(t, srv)
 
-	a := ACL{srv: srv}
+	a := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	var tokenID string
 
@@ -702,7 +702,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 	})
 
 	t.Run("Update auth method linked token and let the SecretID and AuthMethod be defaulted", func(t *testing.T) {
-		acl := ACL{srv: srv}
+		acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 		testSessionID := testauth.StartSession()
 		defer testauth.ResetSession(testSessionID)
@@ -1245,7 +1245,7 @@ func TestACLEndpoint_TokenSet_CustomID(t *testing.T) {
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	// No Create Arg
 	t.Run("no create arg", func(t *testing.T) {
@@ -1514,7 +1514,7 @@ func TestACLEndpoint_TokenSet_anon(t *testing.T) {
 	policy, err := upsertTestPolicy(codec, TestDefaultInitialManagementToken, "dc1")
 	require.NoError(t, err)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	// Assign the policies to a token
 	tokenUpsertReq := structs.ACLTokenSetRequest{
@@ -1570,8 +1570,8 @@ func TestACLEndpoint_TokenDelete(t *testing.T) {
 	// Ensure s2 is authoritative.
 	waitForNewACLReplication(t, s2, structs.ACLReplicateTokens, 1, 1, 0)
 
-	acl := ACL{srv: s1}
-	acl2 := ACL{srv: s2}
+	acl := ACL{srv: s1, logger: testutil.Logger(t)}
+	acl2 := ACL{srv: s2, logger: testutil.Logger(t)}
 
 	existingToken, err := upsertTestToken(codec, TestDefaultInitialManagementToken, "dc1", nil)
 	require.NoError(t, err)
@@ -2016,7 +2016,7 @@ func TestACLEndpoint_PolicySet(t *testing.T) {
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	var policyID string
 
@@ -2133,7 +2133,7 @@ func TestACLEndpoint_PolicySet_globalManagement(t *testing.T) {
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	// Can't change the rules
 	{
@@ -2192,7 +2192,7 @@ func TestACLEndpoint_PolicyDelete(t *testing.T) {
 	existingPolicy, err := upsertTestPolicy(codec, TestDefaultInitialManagementToken, "dc1")
 	require.NoError(t, err)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	req := structs.ACLPolicyDeleteRequest{
 		Datacenter:   "dc1",
@@ -2250,7 +2250,7 @@ func TestACLEndpoint_PolicyList(t *testing.T) {
 	p2, err := upsertTestPolicy(codec, TestDefaultInitialManagementToken, "dc1")
 	require.NoError(t, err)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	req := structs.ACLPolicyListRequest{
 		Datacenter:   "dc1",
@@ -2286,7 +2286,7 @@ func TestACLEndpoint_PolicyResolve(t *testing.T) {
 	p2, err := upsertTestPolicy(codec, TestDefaultInitialManagementToken, "dc1")
 	require.NoError(t, err)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	policies := []string{p1.ID, p2.ID}
 
@@ -2390,7 +2390,7 @@ func TestACLEndpoint_RoleSet(t *testing.T) {
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
 
-	a := ACL{srv: srv}
+	a := ACL{srv: srv, logger: testutil.Logger(t)}
 	var roleID string
 
 	testPolicy1, err := upsertTestPolicy(codec, TestDefaultInitialManagementToken, "dc1")
@@ -2752,7 +2752,7 @@ func TestACLEndpoint_RoleSet_names(t *testing.T) {
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 	testPolicy1, err := upsertTestPolicy(codec, TestDefaultInitialManagementToken, "dc1")
 
 	require.NoError(t, err)
@@ -2837,7 +2837,7 @@ func TestACLEndpoint_RoleDelete(t *testing.T) {
 
 	require.NoError(t, err)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	req := structs.ACLRoleDeleteRequest{
 		Datacenter:   "dc1",
@@ -2903,7 +2903,7 @@ func TestACLEndpoint_RoleResolve(t *testing.T) {
 		r2, err := upsertTestRole(codec, TestDefaultInitialManagementToken, "dc1")
 		require.NoError(t, err)
 
-		acl := ACL{srv: srv}
+		acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 		// Assign the roles to a token
 		tokenUpsertReq := structs.ACLTokenSetRequest{
@@ -4312,7 +4312,7 @@ func TestACLEndpoint_Login(t *testing.T) {
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
 
-	acl := ACL{srv: srv}
+	acl := ACL{srv: srv, logger: testutil.Logger(t)}
 
 	testSessionID := testauth.StartSession()
 	defer testauth.ResetSession(testSessionID)

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -171,6 +171,14 @@ func (c *Catalog) Register(args *structs.RegisterRequest, reply *struct{}) error
 	}
 
 	_, err = c.srv.raftApply(structs.RegisterRequestType, args)
+
+	// Node creation has no service
+	if args.Service != nil {
+		c.logger.Named("audit").Warn("Service registered ",
+			"ID", args.Service.ID, "name", args.Service.Service,
+			"address", args.Service.Address, "port", args.Service.Port,
+			"metaKeys", args.Service.Meta)
+	}
 	return err
 }
 
@@ -415,6 +423,9 @@ func (c *Catalog) Deregister(args *structs.DeregisterRequest, reply *struct{}) e
 	}
 
 	_, err = c.srv.raftApply(structs.DeregisterRequestType, args)
+
+	c.logger.Named("audit").Warn("Service deregistered ", "Node", args.Node, "ID", args.ServiceID)
+
 	return err
 }
 

--- a/agent/consul/kvs_endpoint.go
+++ b/agent/consul/kvs_endpoint.go
@@ -129,6 +129,15 @@ func (k *KVS) Apply(args *structs.KVSRequest, reply *bool) error {
 	if respBool, ok := resp.(bool); ok {
 		*reply = respBool
 	}
+
+	switch args.Op {
+	case api.KVDelete, api.KVDeleteCAS:
+		k.logger.Named("audit").Warn("K/V entry deleted",
+			"accessorID", authz.AccessorID(), "key", args.DirEnt.Key)
+	case api.KVSet, api.KVCAS:
+		k.logger.Named("audit").Warn("K/V entry set", "accessorID", authz.AccessorID(),
+			"key", args.DirEnt.Key, "value", string(args.DirEnt.Value[:]))
+	}
 	return nil
 }
 

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -195,6 +195,67 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			token:   "foo",
 			wantErr: "reserved for internal use",
 		},
+		{
+			name: "connect weights override",
+			sd: &structs.ServiceDefinition{
+				ID:   "web1",
+				Name: "web",
+				Port: 1111,
+				Connect: &structs.ServiceConnect{
+					SidecarService: &structs.ServiceDefinition{
+						Port:    2222,
+						Weights: &structs.Weights{Passing: 22, Warning: 12},
+					},
+				},
+				Weights: &structs.Weights{Passing: 21, Warning: 11},
+			},
+			wantNS: &structs.NodeService{
+				EnterpriseMeta:             *structs.DefaultEnterpriseMetaInDefaultPartition(),
+				Kind:                       structs.ServiceKindConnectProxy,
+				ID:                         "web1-sidecar-proxy",
+				Service:                    "web-sidecar-proxy",
+				Port:                       2222,
+				LocallyRegisteredAsSidecar: true,
+				Weights:                    &structs.Weights{Passing: 22, Warning: 12},
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "web",
+					DestinationServiceID:   "web1",
+					LocalServiceAddress:    "127.0.0.1",
+					LocalServicePort:       1111,
+				},
+			},
+			wantChecks: nil,
+		},
+		{
+			name: "connect weights from service",
+			sd: &structs.ServiceDefinition{
+				ID:   "web1",
+				Name: "web",
+				Port: 1111,
+				Connect: &structs.ServiceConnect{
+					SidecarService: &structs.ServiceDefinition{
+						Port: 2222,
+					},
+				},
+				Weights: &structs.Weights{Passing: 21, Warning: 11},
+			},
+			wantNS: &structs.NodeService{
+				EnterpriseMeta:             *structs.DefaultEnterpriseMetaInDefaultPartition(),
+				Kind:                       structs.ServiceKindConnectProxy,
+				ID:                         "web1-sidecar-proxy",
+				Service:                    "web-sidecar-proxy",
+				Port:                       2222,
+				LocallyRegisteredAsSidecar: true,
+				Weights:                    &structs.Weights{Passing: 21, Warning: 11},
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "web",
+					DestinationServiceID:   "web1",
+					LocalServiceAddress:    "127.0.0.1",
+					LocalServicePort:       1111,
+				},
+			},
+			wantChecks: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -276,84 +337,6 @@ func TestAgent_SidecarPortFromServiceIDLocked(t *testing.T) {
 			name:              "auto ports disabled",
 			autoPortsDisabled: true,
 			wantErr:           "auto-assignment disabled in config",
-		},
-		{
-			name: "connet weights override",
-			sd: &structs.ServiceDefinition{
-				ID:   "web1",
-				Name: "web",
-				Port: 1111,
-				Connect: &structs.ServiceConnect{
-					SidecarService: &structs.ServiceDefinition{
-						Weights: &structs.Weights{Passing: 22, Warning: 12},
-					},
-				},
-				Weights: &structs.Weights{Passing: 21, Warning: 11},
-			},
-			wantNS: &structs.NodeService{
-				EnterpriseMeta:             *structs.DefaultEnterpriseMetaInDefaultPartition(),
-				Kind:                       structs.ServiceKindConnectProxy,
-				ID:                         "web1-sidecar-proxy",
-				Service:                    "web-sidecar-proxy",
-				Port:                       2222,
-				LocallyRegisteredAsSidecar: true,
-				Weights: &structs.Weights{Passing: 22, Warning: 12},
-				Proxy: structs.ConnectProxyConfig{
-					DestinationServiceName: "web",
-					DestinationServiceID:   "web1",
-					LocalServiceAddress:    "127.0.0.1",
-					LocalServicePort:       1111,
-				},
-			},
-			wantChecks: []*structs.CheckType{
-				{
-					Name:     "Connect Sidecar Listening",
-					TCP:      "127.0.0.1:2222",
-					Interval: 10 * time.Second,
-				},
-				{
-					Name:         "Connect Sidecar Aliasing web1",
-					AliasService: "web1",
-				},
-			},
-		},
-		{
-			name: "connect weights from service",
-			sd: &structs.ServiceDefinition{
-				ID:   "web1",
-				Name: "web",
-				Port: 1111,
-				Connect: &structs.ServiceConnect{
-					SidecarService: &structs.ServiceDefinition{},
-				},
-				Weights: &structs.Weights{Passing: 21, Warning: 11},
-			},
-			wantNS: &structs.NodeService{
-				EnterpriseMeta:             *structs.DefaultEnterpriseMetaInDefaultPartition(),
-				Kind:                       structs.ServiceKindConnectProxy,
-				ID:                         "web1-sidecar-proxy",
-				Service:                    "web-sidecar-proxy",
-				Port:                       2222,
-				LocallyRegisteredAsSidecar: true,
-				Weights: &structs.Weights{Passing: 21, Warning: 11},
-				Proxy: structs.ConnectProxyConfig{
-					DestinationServiceName: "web",
-					DestinationServiceID:   "web1",
-					LocalServiceAddress:    "127.0.0.1",
-					LocalServicePort:       1111,
-				},
-			},
-			wantChecks: []*structs.CheckType{
-				{
-					Name:     "Connect Sidecar Listening",
-					TCP:      "127.0.0.1:2222",
-					Interval: 10 * time.Second,
-				},
-				{
-					Name:         "Connect Sidecar Aliasing web1",
-					AliasService: "web1",
-				},
-			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
- Rebase the 1.12.9 audit feature after merge conflicts.
- Fix sidecar tests from [c8a03ec](https://github.com/criteo-forks/consul/pull/166/commits/c8a03ec6bea6b7a3862968eb491058419f328212) after some changes from [93bb76f] (https://github.com/criteo-forks/consul/commit/93bb76f7dbf6d844d4ec9ba62fab70bfde789942)

The fix commit will have to be merged with [c8a03ec](https://github.com/criteo-forks/consul/pull/166/commits/c8a03ec6bea6b7a3862968eb491058419f328212) in further version bumps