### PR TITLE
Add option in prepared query to skip local datacenter

### DIFF
--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -362,6 +362,31 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 		return structs.ErrQueryNotFound
 	}
 
+	// Skip local datacenter query if requested
+	if query.Service.Failover.SkipLocalDatacenter == false {
+		if err := queryLocally(p, args, query, reply); err != nil {
+			return err
+		}
+	}
+
+	// In the happy path where we found some healthy nodes we go with that
+	// and bail out. Otherwise, we fail over and try remote DCs, as allowed
+	// by the query setup.
+	if len(reply.Nodes) == 0 {
+		wrapper := &queryServerWrapper{p.srv}
+		if err := queryFailover(p, wrapper, query, args, reply); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func queryLocally(p *PreparedQuery,
+		args *structs.PreparedQueryExecuteRequest,
+		query *structs.PreparedQuery,
+		reply *structs.PreparedQueryExecuteResponse) error {
+
 	// Execute the query for the local DC.
 	if err := p.execute(query, reply, args.Connect); err != nil {
 		return err
@@ -399,6 +424,7 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 		qs.Node = query.Service.Near
 	}
 
+	state := p.srv.fsm.State()
 	// Respect the magic "_agent" flag.
 	if qs.Node == "_agent" {
 		qs.Node = args.Agent.Node
@@ -430,7 +456,7 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 	}
 
 	// Perform the distance sort
-	err = p.srv.sortNodesByDistanceFrom(qs, reply.Nodes)
+	err := p.srv.sortNodesByDistanceFrom(qs, reply.Nodes)
 	if err != nil {
 		return err
 	}
@@ -455,16 +481,6 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 	// Apply the limit if given.
 	if args.Limit > 0 && len(reply.Nodes) > args.Limit {
 		reply.Nodes = reply.Nodes[:args.Limit]
-	}
-
-	// In the happy path where we found some healthy nodes we go with that
-	// and bail out. Otherwise, we fail over and try remote DCs, as allowed
-	// by the query setup.
-	if len(reply.Nodes) == 0 {
-		wrapper := &queryServerWrapper{p.srv}
-		if err := queryFailover(wrapper, query, args, reply); err != nil {
-			return err
-		}
 	}
 
 	return nil
@@ -689,7 +705,8 @@ func (q *queryServerWrapper) ForwardDC(method, dc string, args interface{}, repl
 
 // queryFailover runs an algorithm to determine which DCs to try and then calls
 // them to try to locate alternative services.
-func queryFailover(q queryServer, query *structs.PreparedQuery,
+func queryFailover(p *PreparedQuery,
+	q queryServer, query *structs.PreparedQuery,
 	args *structs.PreparedQueryExecuteRequest,
 	reply *structs.PreparedQueryExecuteResponse) error {
 
@@ -726,8 +743,10 @@ func queryFailover(q queryServer, query *structs.PreparedQuery,
 		// This will prevent a log of other log spammage if we do not
 		// attempt to talk to datacenters we don't know about.
 		if _, ok := known[dc]; !ok {
-			q.GetLogger().Debug("Skipping unknown datacenter in prepared query", "datacenter", dc)
-			continue
+			if query.Service.Failover.SkipLocalDatacenter == false || dc != p.srv.config.Datacenter {
+				q.GetLogger().Debug("Skipping unknown datacenter in prepared query", "datacenter", dc)
+				continue
+			}
 		}
 
 		// This will make sure we don't re-try something that fails
@@ -751,24 +770,32 @@ func queryFailover(q queryServer, query *structs.PreparedQuery,
 		// through this slice across successive RPC calls.
 		reply.Nodes = nil
 
-		// Note that we pass along the limit since it can be applied
-		// remotely to save bandwidth. We also pass along the consistency
-		// mode information and token we were given, so that applies to
-		// the remote query as well.
-		remote := &structs.PreparedQueryExecuteRemoteRequest{
-			Datacenter:   dc,
-			Query:        *query,
-			Limit:        args.Limit,
-			QueryOptions: args.QueryOptions,
-			Connect:      args.Connect,
-		}
-		if err := q.ForwardDC("PreparedQuery.ExecuteRemote", dc, remote, reply); err != nil {
-			q.GetLogger().Warn("Failed querying for service in datacenter",
-				"service", query.Service.Service,
-				"datacenter", dc,
-				"error", err,
-			)
-			continue
+	if query.Service.Failover.SkipLocalDatacenter == true && dc == p.srv.config.Datacenter {
+			if err := queryLocally(p, args, query, reply); err != nil {
+				q.GetLogger().Warn("[WARN] consul.prepared_query: Failed querying for service " +
+									 "'%s' in local datacenter: %s", query.Service.Service, err)
+				continue
+			}
+		} else {
+			// Note that we pass along the limit since it can be applied
+			// remotely to save bandwidth. We also pass along the consistency
+			// mode information and token we were given, so that applies to
+			// the remote query as well.
+			remote := &structs.PreparedQueryExecuteRemoteRequest{
+				Datacenter:   dc,
+				Query:        *query,
+				Limit:        args.Limit,
+				QueryOptions: args.QueryOptions,
+				Connect:      args.Connect,
+			}
+			if err := q.ForwardDC("PreparedQuery.ExecuteRemote", dc, remote, reply); err != nil {
+				q.GetLogger().Warn("Failed querying for service in datacenter",
+					"service", query.Service.Service,
+					"datacenter", dc,
+					"error", err,
+				)
+				continue
+			}
 		}
 
 		// We can stop if we found some nodes.

--- a/agent/structs/prepared_query.go
+++ b/agent/structs/prepared_query.go
@@ -13,6 +13,9 @@ import (
 // QueryDatacenterOptions sets options about how we fail over if there are no
 // healthy nodes in the local datacenter.
 type QueryDatacenterOptions struct {
+	// Skip lookup in local datacenter
+	SkipLocalDatacenter bool
+
 	// NearestN is set to the number of remote datacenters to try, based on
 	// network coordinates.
 	NearestN int

--- a/api/prepared_query.go
+++ b/api/prepared_query.go
@@ -3,6 +3,9 @@ package api
 // QueryDatacenterOptions sets options about how we fail over if there are no
 // healthy nodes in the local datacenter.
 type QueryDatacenterOptions struct {
+	// Skip lookup in local datacenter
+	SkipLocalDatacenter bool
+
 	// NearestN is set to the number of remote datacenters to try, based on
 	// network coordinates.
 	NearestN int

--- a/website/content/api-docs/query.mdx
+++ b/website/content/api-docs/query.mdx
@@ -186,6 +186,9 @@ The table below shows this endpoint's support for
     the query is executed. It allows the use of nodes in other datacenters with
     very little configuration.
 
+    - `SkipLocalDatacenter` `(bool)` - Specifies that the query should not be executed on the
+      local nodes and forwarded to the remote datacenters directly.
+
     - `NearestN` `(int: 0)` - Specifies that the query will be forwarded to up
       to `NearestN` other datacenters based on their estimated network round
       trip time using [Network Coordinates](/docs/architecture/coordinates)
@@ -265,7 +268,8 @@ The table below shows this endpoint's support for
     "Service": "redis",
     "Failover": {
       "NearestN": 3,
-      "Datacenters": ["dc1", "dc2"]
+      "Datacenters": ["dc1", "dc2"],
+      "SkipLocalDatacenter": false
     },
     "Near": "node1",
     "OnlyPassing": false,
@@ -341,7 +345,8 @@ $ curl \
       "Service": "redis",
       "Failover": {
         "NearestN": 3,
-        "Datacenters": ["dc1", "dc2"]
+        "Datacenters": ["dc1", "dc2"],
+        "SkipLocalDatacenter": false
       },
       "OnlyPassing": false,
       "Tags": ["primary", "!experimental"],
@@ -663,7 +668,8 @@ $ curl \
       "Service": "mysql-customer",
       "Failover": {
         "NearestN": 3,
-        "Datacenters": ["dc1", "dc2"]
+        "Datacenters": ["dc1", "dc2"],
+        "SkipLocalDatacenter": false
       },
       "OnlyPassing": true,
       "Tags": ["primary"],


### PR DESCRIPTION
- Add option SkipLocalDatacenter in Failover section, defaulted to false, which enable the possibility to never execute the query in the local datacenter when set to true.
- Also when the option is enabled, if the local datacenter is listed in the failover datacenters, execute the query locally instead of triggering remotely.

This patch solves issue described in https://github.com/hashicorp/consul/issues/3250