### PR TITLE
Add option in prepared query to skip local datacenter

### DIFF
--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -368,6 +368,31 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 		return structs.ErrQueryNotFound
 	}
 
+	// Skip local datacenter query if requested
+	if query.Service.Failover.SkipLocalDatacenter == false {
+		if err := queryLocally(p, args, query, reply); err != nil {
+			return err
+		}
+	}
+
+	// In the happy path where we found some healthy nodes we go with that
+	// and bail out. Otherwise, we fail over and try remote DCs, as allowed
+	// by the query setup.
+	if len(reply.Nodes) == 0 {
+		wrapper := &queryServerWrapper{srv: p.srv, executeRemote: p.ExecuteRemote}
+		if err := queryFailover(p, wrapper, query, args, reply); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func queryLocally(p *PreparedQuery,
+		args *structs.PreparedQueryExecuteRequest,
+		query *structs.PreparedQuery,
+		reply *structs.PreparedQueryExecuteResponse) error {
+
 	// Execute the query for the local DC.
 	if err := p.execute(query, reply, args.Connect); err != nil {
 		return err
@@ -405,6 +430,7 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 		qs.Node = query.Service.Near
 	}
 
+	state := p.srv.fsm.State()
 	// Respect the magic "_agent" flag.
 	if qs.Node == "_agent" {
 		qs.Node = args.Agent.Node
@@ -436,7 +462,7 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 	}
 
 	// Perform the distance sort
-	err = p.srv.sortNodesByDistanceFrom(qs, reply.Nodes)
+	err := p.srv.sortNodesByDistanceFrom(qs, reply.Nodes)
 	if err != nil {
 		return err
 	}
@@ -461,16 +487,6 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 	// Apply the limit if given.
 	if args.Limit > 0 && len(reply.Nodes) > args.Limit {
 		reply.Nodes = reply.Nodes[:args.Limit]
-	}
-
-	// In the happy path where we found some healthy nodes we go with that
-	// and bail out. Otherwise, we fail over and try remote DCs, as allowed
-	// by the query setup.
-	if len(reply.Nodes) == 0 {
-		wrapper := &queryServerWrapper{srv: p.srv, executeRemote: p.ExecuteRemote}
-		if err := queryFailover(wrapper, query, args, reply); err != nil {
-			return err
-		}
 	}
 
 	return nil
@@ -707,7 +723,8 @@ func (q *queryServerWrapper) GetOtherDatacentersByDistance() ([]string, error) {
 
 // queryFailover runs an algorithm to determine which DCs to try and then calls
 // them to try to locate alternative services.
-func queryFailover(q queryServer, query *structs.PreparedQuery,
+func queryFailover(p *PreparedQuery,
+	q queryServer, query *structs.PreparedQuery,
 	args *structs.PreparedQueryExecuteRequest,
 	reply *structs.PreparedQueryExecuteResponse) error {
 
@@ -745,8 +762,10 @@ func queryFailover(q queryServer, query *structs.PreparedQuery,
 		// attempt to talk to datacenters we don't know about.
 		if dc := target.Datacenter; dc != "" {
 			if _, ok := known[dc]; !ok {
-				q.GetLogger().Debug("Skipping unknown datacenter in prepared query", "datacenter", dc)
-				continue
+				if query.Service.Failover.SkipLocalDatacenter == false || dc != p.srv.config.Datacenter {
+					q.GetLogger().Debug("Skipping unknown datacenter in prepared query", "datacenter", dc)
+					continue
+				}
 			}
 
 			// This will make sure we don't re-try something that fails
@@ -783,26 +802,34 @@ func queryFailover(q queryServer, query *structs.PreparedQuery,
 			dc = q.GetLocalDC()
 		}
 
-		// Note that we pass along the limit since may be applied
-		// remotely to save bandwidth. We also pass along the consistency
-		// mode information and token we were given, so that applies to
-		// the remote query as well.
-		remote := &structs.PreparedQueryExecuteRemoteRequest{
-			Datacenter:   dc,
-			Query:        *query,
-			Limit:        args.Limit,
-			QueryOptions: args.QueryOptions,
-			Connect:      args.Connect,
-		}
+		if query.Service.Failover.SkipLocalDatacenter == true && dc == p.srv.config.Datacenter {
+			if err := queryLocally(p, args, query, reply); err != nil {
+				q.GetLogger().Warn("[WARN] consul.prepared_query: Failed querying for service " +
+									 "'%s' in local datacenter: %s", query.Service.Service, err)
+				continue
+			}
+		} else {
+			// Note that we pass along the limit since may be applied
+			// remotely to save bandwidth. We also pass along the consistency
+			// mode information and token we were given, so that applies to
+			// the remote query as well.
+			remote := &structs.PreparedQueryExecuteRemoteRequest{
+				Datacenter:   dc,
+				Query:        *query,
+				Limit:        args.Limit,
+				QueryOptions: args.QueryOptions,
+				Connect:      args.Connect,
+			}
 
-		if err = q.ExecuteRemote(remote, reply); err != nil {
-			q.GetLogger().Warn("Failed querying for service in datacenter",
-				"service", query.Service.Service,
-				"peerName", query.Service.PeerName,
-				"datacenter", dc,
-				"error", err,
-			)
-			continue
+			if err = q.ExecuteRemote(remote, reply); err != nil {
+				q.GetLogger().Warn("Failed querying for service in datacenter",
+					"service", query.Service.Service,
+					"peerName", query.Service.PeerName,
+					"datacenter", dc,
+					"error", err,
+				)
+				continue
+			}
 		}
 
 		// We can stop if we found some nodes.

--- a/agent/consul/prepared_query_endpoint_test.go
+++ b/agent/consul/prepared_query_endpoint_test.go
@@ -2479,6 +2479,179 @@ func TestPreparedQuery_Execute(t *testing.T) {
 	})
 }
 
+func prepared_query_apply_execute_and_check(t *testing.T, codec rpc.ClientCodec, query structs.PreparedQueryRequest, expected_nodes_count int, expected_failovers_count int) {
+	var resp string
+	if err := msgpackrpc.CallWithCodec(codec, "PreparedQuery.Apply", &query, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	req := structs.PreparedQueryExecuteRequest{
+		Datacenter:    "dc1",
+		QueryIDOrName: resp,
+	}
+	var reply structs.PreparedQueryExecuteResponse
+	if err := msgpackrpc.CallWithCodec(codec, "PreparedQuery.Execute", &req, &reply); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// It should not try any failover dc
+	if len(reply.Nodes) != expected_nodes_count {
+		t.Fatalf("incorrect nodes count: %v", reply)
+	}
+	if reply.Failovers != expected_failovers_count {
+		t.Fatalf("incorrect failovers count: %v", reply)
+	}
+}
+
+func TestPreparedQuery_Execute_Failover(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	// Create cluster of 3 dcs: dc2 <-> dc1 <-> dc3
+	t.Parallel()
+	dir1, s1 := testServer(t)
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc2"
+		c.PrimaryDatacenter = "dc2"
+	})
+	defer os.RemoveAll(dir2)
+	defer s2.Shutdown()
+
+	dir3, s3 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc3"
+		c.PrimaryDatacenter = "dc3"
+	})
+	defer os.RemoveAll(dir3)
+	defer s3.Shutdown()
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+	testrpc.WaitForLeader(t, s2.RPC, "dc2")
+	testrpc.WaitForLeader(t, s3.RPC, "dc3")
+
+	// Try to join.
+	joinWAN(t, s2, s1)
+	joinWAN(t, s3, s1)
+
+	// Set up nodes and service in the catalog.
+	{
+		// One node in dc1
+		req := structs.RegisterRequest{
+			Datacenter: "dc1",
+			Node:       "foo",
+			Address:    "127.0.0.1",
+			Service: &structs.NodeService{
+				Service: "redis",
+				Tags:    []string{"primary"},
+				Port:    8000,
+			},
+		}
+		var reply struct{}
+		if err := msgpackrpc.CallWithCodec(codec, "Catalog.Register", &req, &reply); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		// Two nodes in dc2
+		for i, svc_name := range []string{"foo", "bar"} {
+			req = structs.RegisterRequest{
+				Datacenter: "dc2",
+				Node:       svc_name,
+				Address:    "127.0.0.1",
+				Service: &structs.NodeService{
+					Service: "redis",
+					Tags:    []string{"primary"},
+					Port:    8000+i,
+				},
+			}
+			if err := msgpackrpc.CallWithCodec(codec, "Catalog.Register", &req, &reply); err != nil {
+				t.Fatalf("err: %v", err)
+			}
+		}
+		// No nodes in dc3
+	}
+
+	// Set up a bare bones query with failover enabled
+	// But with dc1 as first failover dc
+	query := structs.PreparedQueryRequest{
+		Datacenter: "dc1",
+		Op:         structs.PreparedQueryCreate,
+		Query: &structs.PreparedQuery{
+			Name: "test_failover_enabled_dc1_first",
+			Service: structs.ServiceQuery{
+				Service: "redis",
+				Failover: structs.QueryFailoverOptions {
+					SkipLocalDatacenter: true,
+					Datacenters: []string{"dc1", "dc2"},
+				},
+			},
+		},
+	}
+	// It should fallback on local dc since it appears first in Failover dc list
+	prepared_query_apply_execute_and_check(t, codec, query, 1, 1)
+
+	// Set up a bare bones query with failover enabled
+	// But without dc1 as failover dc
+	query = structs.PreparedQueryRequest{
+		Datacenter: "dc1",
+		Op:         structs.PreparedQueryCreate,
+		Query: &structs.PreparedQuery{
+			Name: "test_failover_enabled_withou_dc1_as_failover",
+			Service: structs.ServiceQuery{
+				Service: "redis",
+				Failover: structs.QueryFailoverOptions {
+					SkipLocalDatacenter: true,
+					Datacenters: []string{"dc2"},
+				},
+			},
+		},
+	}
+	// It should fallback on local dc since it appears first in Failover dc list
+	prepared_query_apply_execute_and_check(t, codec, query, 2, 1)
+
+	// Set up a bare bones query with failover enabled
+	// with list of inexistent/undeclared failover dcs
+	query = structs.PreparedQueryRequest{
+		Datacenter: "dc1",
+		Op:         structs.PreparedQueryCreate,
+		Query: &structs.PreparedQuery{
+			Name: "test_failover_enabled_inexistent_dcs",
+			Service: structs.ServiceQuery{
+				Service: "redis",
+				Failover: structs.QueryFailoverOptions {
+					SkipLocalDatacenter: true,
+					Datacenters: []string{"dc4", "dc5"},
+				},
+			},
+		},
+	}
+	// It should not try any failover dc
+	prepared_query_apply_execute_and_check(t, codec, query, 0, 0)
+
+	// Set up a bare bones query with failover enabled
+	// with list of inexistent dc then dc3 (0 node) and finally dc2 (2 nodes)
+	query = structs.PreparedQueryRequest{
+		Datacenter: "dc1",
+		Op:         structs.PreparedQueryCreate,
+		Query: &structs.PreparedQuery{
+			Name: "test_failover_enabled_choose_last_dc",
+			Service: structs.ServiceQuery{
+				Service: "redis",
+				Failover: structs.QueryFailoverOptions {
+					SkipLocalDatacenter: true,
+					Datacenters: []string{"dc4", "dc3", "dc2"},
+				},
+			},
+		},
+	}
+	// It should fallback on the last dc in the failover list
+	// Not that when dc is not declared, the failover count is not increased
+	prepared_query_apply_execute_and_check(t, codec, query, 2, 2)
+}
+
 func TestPreparedQuery_Execute_ForwardLeader(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -2990,6 +3163,13 @@ func TestPreparedQuery_queryFailover(t *testing.T) {
 		}
 	}
 
+	_, conf := testServerConfig(t)
+	srv, err := newServer(t, conf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	prepared_query := PreparedQuery{srv, hclog.Default()}
+
 	// Datacenters are available but the query doesn't use them.
 	{
 		mock := &mockQueryServer{
@@ -2997,7 +3177,7 @@ func TestPreparedQuery_queryFailover(t *testing.T) {
 		}
 
 		var reply structs.PreparedQueryExecuteResponse
-		if err := queryFailover(mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if len(reply.Nodes) != 0 || reply.Datacenter != "" || reply.Failovers != 0 {
@@ -3013,7 +3193,7 @@ func TestPreparedQuery_queryFailover(t *testing.T) {
 		}
 
 		var reply structs.PreparedQueryExecuteResponse
-		err := queryFailover(mock, query, &structs.PreparedQueryExecuteRequest{}, &reply)
+		err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply)
 		if err == nil || !strings.Contains(err.Error(), "XXX") {
 			t.Fatalf("bad: %v", err)
 		}
@@ -3030,7 +3210,7 @@ func TestPreparedQuery_queryFailover(t *testing.T) {
 		}
 
 		var reply structs.PreparedQueryExecuteResponse
-		if err := queryFailover(mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if len(reply.Nodes) != 0 || reply.Datacenter != "" || reply.Failovers != 0 {
@@ -3052,7 +3232,7 @@ func TestPreparedQuery_queryFailover(t *testing.T) {
 		}
 
 		var reply structs.PreparedQueryExecuteResponse
-		if err := queryFailover(mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if len(reply.Nodes) != 3 ||
@@ -3079,7 +3259,7 @@ func TestPreparedQuery_queryFailover(t *testing.T) {
 		}
 
 		var reply structs.PreparedQueryExecuteResponse
-		if err := queryFailover(mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if len(reply.Nodes) != 3 ||
@@ -3100,7 +3280,7 @@ func TestPreparedQuery_queryFailover(t *testing.T) {
 		}
 
 		var reply structs.PreparedQueryExecuteResponse
-		if err := queryFailover(mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if len(reply.Nodes) != 0 ||
@@ -3128,7 +3308,7 @@ func TestPreparedQuery_queryFailover(t *testing.T) {
 		}
 
 		var reply structs.PreparedQueryExecuteResponse
-		if err := queryFailover(mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if len(reply.Nodes) != 3 ||
@@ -3156,7 +3336,7 @@ func TestPreparedQuery_queryFailover(t *testing.T) {
 		}
 
 		var reply structs.PreparedQueryExecuteResponse
-		if err := queryFailover(mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if len(reply.Nodes) != 3 ||
@@ -3184,7 +3364,7 @@ func TestPreparedQuery_queryFailover(t *testing.T) {
 		}
 
 		var reply structs.PreparedQueryExecuteResponse
-		if err := queryFailover(mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if len(reply.Nodes) != 3 ||
@@ -3216,7 +3396,7 @@ func TestPreparedQuery_queryFailover(t *testing.T) {
 		}
 
 		var reply structs.PreparedQueryExecuteResponse
-		if err := queryFailover(mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if len(reply.Nodes) != 3 ||
@@ -3247,7 +3427,7 @@ func TestPreparedQuery_queryFailover(t *testing.T) {
 		}
 
 		var reply structs.PreparedQueryExecuteResponse
-		if err := queryFailover(mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		if len(reply.Nodes) != 3 ||
@@ -3281,7 +3461,7 @@ func TestPreparedQuery_queryFailover(t *testing.T) {
 		}
 
 		var reply structs.PreparedQueryExecuteResponse
-		if err := queryFailover(mock, query, &structs.PreparedQueryExecuteRequest{
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{
 			Limit:        5,
 			QueryOptions: structs.QueryOptions{RequireConsistent: true},
 		}, &reply); err != nil {
@@ -3316,12 +3496,83 @@ func TestPreparedQuery_queryFailover(t *testing.T) {
 		}
 
 		var reply structs.PreparedQueryExecuteResponse
-		if err := queryFailover(mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 		require.Equal(t, "cluster-02", reply.PeerName)
 		require.Equal(t, 3, reply.Failovers)
 		require.Equal(t, nodes(), reply.Nodes)
 		require.Equal(t, "peer:cluster-01|dc44:PreparedQuery.ExecuteRemote|peer:cluster-02", mock.JoinQueryLog())
+	}
+
+	// Failover on dc2 worked
+	query.Service.Failover.Datacenters = []string{"dc1", "dc2"}
+	query.Service.Failover.SkipLocalDatacenter = true
+	{
+		mock := &mockQueryServer{
+			Datacenters: []string{"dc1", "dc2", "dc3"},
+			QueryFn: func(req *structs.PreparedQueryExecuteRemoteRequest, reply *structs.PreparedQueryExecuteResponse) error {
+				if req.Datacenter == "dc2" {
+					reply.Nodes = nodes()
+				}
+				return nil
+			},
+		}
+
+		var reply structs.PreparedQueryExecuteResponse
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		// - 3 nodes are returned
+		// - failed over twice (local dc since it's in the failover list then remote dc)
+		require.Equal(t, nodes(), reply.Nodes)
+		require.Equal(t, 2, reply.Failovers)
+	}
+
+	// Failover on dc1 returned no nodes
+	query.Service.Failover.Datacenters = []string{"dc1"}
+	query.Service.Failover.SkipLocalDatacenter = true
+	{
+		mock := &mockQueryServer{
+			// Datacenters: []string{"dc1", "dc2", "dc3", "xxx", "dc4"},
+			Datacenters: []string{"dc1", "dc2", "dc3"},
+			QueryFn: func(req *structs.PreparedQueryExecuteRemoteRequest, reply *structs.PreparedQueryExecuteResponse) error {
+				if req.Datacenter == "dc2" {
+					reply.Nodes = nodes()
+				}
+				return nil
+			},
+		}
+
+		var reply structs.PreparedQueryExecuteResponse
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		// - no nodes are returned
+		// - failed over once (local dc only since it's in the failover list)
+		require.Equal(t, 0, len(reply.Nodes))
+		require.Equal(t, 1, reply.Failovers)
+	}
+
+	// Failover on dc3 worked
+	query.Service.Failover.Datacenters = []string{"dc1", "dc2", "dc3"}
+	query.Service.Failover.SkipLocalDatacenter = true
+	{
+		mock := &mockQueryServer{
+			Datacenters: []string{"dc1", "dc2", "dc3"},
+			QueryFn: func(req *structs.PreparedQueryExecuteRemoteRequest, reply *structs.PreparedQueryExecuteResponse) error {
+				if req.Datacenter == "dc3" {
+					reply.Nodes = nodes()
+				}
+				return nil
+			},
+		}
+
+		var reply structs.PreparedQueryExecuteResponse
+		if err := queryFailover(&prepared_query, mock, query, &structs.PreparedQueryExecuteRequest{}, &reply); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		require.Equal(t, nodes(), reply.Nodes)
+		require.Equal(t, 3, reply.Failovers)
 	}
 }

--- a/agent/structs/prepared_query.go
+++ b/agent/structs/prepared_query.go
@@ -13,6 +13,9 @@ import (
 // QueryFailoverOptions sets options about how we fail over if there are no
 // healthy nodes in the local datacenter.
 type QueryFailoverOptions struct {
+	// Skip lookup in local datacenter
+	SkipLocalDatacenter bool
+
 	// NearestN is set to the number of remote datacenters to try, based on
 	// network coordinates.
 	NearestN int

--- a/api/prepared_query.go
+++ b/api/prepared_query.go
@@ -3,6 +3,9 @@ package api
 // QueryFailoverOptions sets options about how we fail over if there are no
 // healthy nodes in the local datacenter.
 type QueryFailoverOptions struct {
+	// Skip lookup in local datacenter
+	SkipLocalDatacenter bool
+
 	// NearestN is set to the number of remote datacenters to try, based on
 	// network coordinates.
 	NearestN int

--- a/website/content/api-docs/query.mdx
+++ b/website/content/api-docs/query.mdx
@@ -186,6 +186,9 @@ The table below shows this endpoint's support for
     the query is executed. It allows the use of nodes in other datacenters with
     very little configuration.
 
+    - `SkipLocalDatacenter` `(bool)` - Specifies that the query should not be executed on the
+      local nodes and forwarded to the remote datacenters directly.
+
     - `NearestN` `(int: 0)` - Specifies that the query will be forwarded to up
       to `NearestN` other datacenters based on their estimated network round
       trip time using [Network Coordinates](/docs/architecture/coordinates)
@@ -276,7 +279,8 @@ The table below shows this endpoint's support for
     "Service": "redis",
     "Failover": {
       "NearestN": 3,
-      "Datacenters": ["dc1", "dc2"]
+      "Datacenters": ["dc1", "dc2"],
+      "SkipLocalDatacenter": false
     },
     "Near": "node1",
     "OnlyPassing": false,
@@ -352,7 +356,8 @@ $ curl \
       "Service": "redis",
       "Failover": {
         "NearestN": 3,
-        "Datacenters": ["dc1", "dc2"]
+        "Datacenters": ["dc1", "dc2"],
+        "SkipLocalDatacenter": false
       },
       "OnlyPassing": false,
       "Tags": ["primary", "!experimental"],
@@ -674,7 +679,8 @@ $ curl \
       "Service": "mysql-customer",
       "Failover": {
         "NearestN": 3,
-        "Datacenters": ["dc1", "dc2"]
+        "Datacenters": ["dc1", "dc2"],
+        "SkipLocalDatacenter": false
       },
       "OnlyPassing": true,
       "Tags": ["primary"],


### PR DESCRIPTION
Backport from branch 1.12.9-criteo

- Add option SkipLocalDatacenter in Failover section, defaulted to false, which enable the possibility to never execute the query in the local datacenter when set to true.
- Also when the option is enabled, if the local datacenter is listed in the failover datacenters, execute the query locally instead of triggering remotely.
- Add more tests on prepared query

This patch solves issue described in https://github.com/hashicorp/consul/issues/3250