### PR TITLE
[HACK] Silence an error when restoring a ServiceVirtualIP from a snapshot

### DIFF
--- a/agent/consul/fsm/snapshot_oss.go
+++ b/agent/consul/fsm/snapshot_oss.go
@@ -927,7 +927,9 @@ func restoreServiceVirtualIP(header *SnapshotHeader, restore *state.Restore, dec
 	}
 
 	if err := restore.ServiceVirtualIP(vip); err != nil {
-		return err
+		//return err
+		fmt.Println("[DEBUG] bypass ServiceVirtualIP snapshot restore error")
+		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
After a version bump issue from 1.12.9 to 1.13.8, we reverted back to 1.12.9.
Since then, re-upgrading to 1.13.8 (or any available major) isn't possible due to a snapshot restore issue.
A ServiceVirtualIP ends up with an empty name and consul can't recover from it.

Silencing this warning will enable us to bump the major while dumping the broken ServiceVirtualIP object, then we can revert back to a non-hacked version.

This commit should never have to be ported to any other version