### PR TITLE
api: fix non-connect endpoints give downstream connect informations

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1188,12 +1188,6 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 		// persist it in the actual state/catalog. SidecarService is meant to be a
 		// registration syntax sugar so don't propagate it any further.
 		ns.Connect.SidecarService = nil
-		if sidecar != nil {
-		   ns.Proxy.LocalServicePort = sidecar.Port
-		   ns.Proxy.LocalServiceAddress = sidecar.Address
-		   ns.Proxy.DestinationServiceID = sidecar.ID
-		   ns.Proxy.DestinationServiceName = sidecar.Service
-		}
 	}
 
 	// Add the service.


### PR DESCRIPTION
Our custom patch that exposes connect informations to non-connect endpoint is not working as expected in version 1.13.X. Indeed, a refctor has been done in https://github.com/hashicorp/consul/pull/14057 to only avoid some race condition while allocating the connect port.

In this patch, in order to keep the mindset, now register the sidecar first, and then the actual service, which allows to collect the sidecar port.

Also removed from agent_endpoint since this doesn't seem to be used.