### PR TITLE
api: fix non-connect endpoints give downstream connect informations

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1198,18 +1198,6 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 		replaceExistingChecks = true
 	}
 
-	addReq := AddServiceRequest{
-		Service:               ns,
-		chkTypes:              chkTypes,
-		persist:               true,
-		token:                 token,
-		Source:                ConfigSourceRemote,
-		replaceExistingChecks: replaceExistingChecks,
-	}
-	if err := s.agent.AddService(addReq); err != nil {
-		return nil, err
-	}
-
 	if sidecar != nil {
 		addReq := AddServiceRequest{
 			Service:               sidecar,
@@ -1222,7 +1210,25 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 		if err := s.agent.AddService(addReq); err != nil {
 			return nil, err
 		}
+
+		ns.Proxy.LocalServicePort = sidecar.Port
+		ns.Proxy.LocalServiceAddress = sidecar.Address
+		ns.Proxy.DestinationServiceID = sidecar.ID
+		ns.Proxy.DestinationServiceName = sidecar.Service
 	}
+
+	addReq := AddServiceRequest{
+		Service:               ns,
+		chkTypes:              chkTypes,
+		persist:               true,
+		token:                 token,
+		Source:                ConfigSourceRemote,
+		replaceExistingChecks: replaceExistingChecks,
+	}
+	if err := s.agent.AddService(addReq); err != nil {
+		return nil, err
+	}
+
 	s.syncChanges()
 	return nil, nil
 }

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3686,10 +3686,10 @@ func testAgent_RegisterService_TranslateKeys(t *testing.T, extraHCL string) {
 				Weights:           &structs.Weights{Passing: 16, Warning: 0},
 				Kind:              structs.ServiceKindConnectProxy,
 				Proxy: structs.ConnectProxyConfig{
-					DestinationServiceName: "web",
-					DestinationServiceID:   "web",
-					LocalServiceAddress:    tt.ip,
-					LocalServicePort:       1234,
+					DestinationServiceName: "test-proxy",
+					DestinationServiceID:   "test-sidecar-proxy",
+					LocalServiceAddress:    "",
+					LocalServicePort:       8001,
 					Config: map[string]interface{}{
 						"destination_type": "proxy.config is 'opaque' so should not get translated",
 					},


### PR DESCRIPTION
Services defined in config files had sidecar info but the services registered on-the-fly did not. This fixes it.

Register the sidecar first, set the proxy fields to the sidecar params then register the service

