### PR TITLE
Bump version to 1.16.3-criteo2

### DIFF
--- a/version/VERSION
+++ b/version/VERSION
@@ -1,1 +1,1 @@
-1.16.3-criteodev
+1.16.3-criteo2


### PR DESCRIPTION
As the package -criteo1 has been deployed but is flagged -criteodev
we go straight to -criteo2