### PR TITLE
Add option in prepared query to include all nodes

### DIFF
--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -578,9 +578,11 @@ func (p *PreparedQuery) execute(query *structs.PreparedQuery,
 
 	// Filter out any unhealthy nodes.
 	filterType := structs.HealthFilterExcludeCritical
-	if query.Service.OnlyPassing {
-		filterType = structs.HealthFilterIncludeOnlyPassing
+	if query.Service.IncludeAll {
+		filterType = structs.HealthFilterIncludeAll
 
+	} else if query.Service.OnlyPassing {
+		filterType = structs.HealthFilterIncludeOnlyPassing
 	}
 
 	nodes = nodes.Filter(structs.CheckServiceNodeFilterOptions{FilterType: filterType,

--- a/agent/structs/prepared_query.go
+++ b/agent/structs/prepared_query.go
@@ -86,6 +86,10 @@ type ServiceQuery struct {
 	// local datacenter.
 	Failover QueryFailoverOptions
 
+	// If IncludeAll is true then we will only include all nodes
+	// whatever the health checks
+	IncludeAll bool
+
 	// If OnlyPassing is true then we will only include nodes with passing
 	// health checks (critical AND warning checks will cause a node to be
 	// discarded)


### PR DESCRIPTION
- Add option IncludeAll in Service Query section, defaulted to false, which enable the possibility to fetched all nodes whatever the health check
- Add more tests on prepared query

JIRA: DISCO-890