### PR TITLE
Fix fork go-tests lint and TLS API failure

### DIFF
--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -334,7 +334,7 @@ func (a *ACL) TokenRead(args *structs.ACLTokenGetRequest, reply *structs.ACLToke
 				return err
 			} else if token == nil {
 				// token does not exist
-				if ns := args.EnterpriseMeta.NamespaceOrEmpty(); ns != "" {
+				if ns := args.NamespaceOrEmpty(); ns != "" {
 					err = fmt.Errorf("token not found in namespace %s: %w", ns, acl.ErrNotFound)
 					return err
 				}
@@ -512,7 +512,7 @@ func (a *ACL) TokenClone(args *structs.ACLTokenSetRequest, reply *structs.ACLTok
 	if err != nil {
 		return err
 	} else if token == nil {
-		if ns := args.ACLToken.EnterpriseMeta.NamespaceOrEmpty(); ns != "" {
+		if ns := args.ACLToken.NamespaceOrEmpty(); ns != "" {
 			err = fmt.Errorf("token not found in namespace %s: %w", ns, acl.ErrNotFound)
 			return err
 		}
@@ -691,7 +691,7 @@ func (a *ACL) TokenDelete(args *structs.ACLTokenDeleteRequest, reply *string) er
 		return err
 	} else {
 		// in Primary Datacenter but the token does not exist - return early indicating it wasn't found.
-		if ns := args.EnterpriseMeta.NamespaceOrEmpty(); ns != "" {
+		if ns := args.NamespaceOrEmpty(); ns != "" {
 			err = fmt.Errorf("token not found in namespace %s: %w", ns, acl.ErrNotFound)
 			return err
 		}
@@ -1594,7 +1594,7 @@ func (a *ACL) RoleDelete(args *structs.ACLRoleDeleteRequest, reply *string) erro
 	}
 
 	if role == nil {
-		if ns := args.EnterpriseMeta.NamespaceOrEmpty(); ns != "" {
+		if ns := args.NamespaceOrEmpty(); ns != "" {
 			err = fmt.Errorf("role not found in namespace %s: %w", ns, acl.ErrNotFound)
 			return err
 		}

--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -376,7 +376,7 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 	}
 
 	// Skip local datacenter query if requested
-	if query.Service.Failover.SkipLocalDatacenter == false {
+	if !query.Service.Failover.SkipLocalDatacenter {
 		if err := queryLocally(p, args, query, reply); err != nil {
 			return err
 		}
@@ -805,7 +805,7 @@ func queryFailover(p *PreparedQuery,
 		// attempt to talk to datacenters we don't know about.
 		if dc := target.Datacenter; dc != "" {
 			if _, ok := known[dc]; !ok {
-				if query.Service.Failover.SkipLocalDatacenter == false || dc != p.srv.config.Datacenter {
+				if !query.Service.Failover.SkipLocalDatacenter || dc != p.srv.config.Datacenter {
 					q.GetLogger().Debug("Skipping unknown datacenter in prepared query", "datacenter", dc)
 					continue
 				}
@@ -871,7 +871,7 @@ func targetSelector(p *PreparedQuery,
 		dc = q.GetLocalDC()
 	}
 
-	if query.Service.Failover.SkipLocalDatacenter == true && dc == p.srv.config.Datacenter {
+	if query.Service.Failover.SkipLocalDatacenter && dc == p.srv.config.Datacenter {
 		if err := queryLocally(p, args, &query, reply); err != nil {
 			q.GetLogger().Warn("[WARN] consul.prepared_query: Failed querying for service "+
 				"'%s' in local datacenter: %s", query.Service.Service, err)

--- a/agent/structs/acl_templated_policy.go
+++ b/agent/structs/acl_templated_policy.go
@@ -34,23 +34,23 @@ var ACLTemplatedPolicyAPIGatewaySchema string
 type ACLTemplatedPolicies []*ACLTemplatedPolicy
 
 const (
-	ACLTemplatedPolicyServiceID     = "00000000-0000-0000-0000-000000000003"
-	ACLTemplatedPolicyNodeID        = "00000000-0000-0000-0000-000000000004"
-	ACLTemplatedPolicyDNSID         = "00000000-0000-0000-0000-000000000005"
-	ACLTemplatedPolicyNomadServerID = "00000000-0000-0000-0000-000000000006"
-	_                               = "00000000-0000-0000-0000-000000000007" // formerly workload identity
-	ACLTemplatedPolicyAPIGatewayID  = "00000000-0000-0000-0000-000000000008"
-	ACLTemplatedPolicyNomadClientID = "00000000-0000-0000-0000-000000000009"
+	ACLTemplatedPolicyServiceID      = "00000000-0000-0000-0000-000000000003"
+	ACLTemplatedPolicyNodeID         = "00000000-0000-0000-0000-000000000004"
+	ACLTemplatedPolicyDNSID          = "00000000-0000-0000-0000-000000000005"
+	ACLTemplatedPolicyNomadServerID  = "00000000-0000-0000-0000-000000000006"
+	_                                = "00000000-0000-0000-0000-000000000007" // formerly workload identity
+	ACLTemplatedPolicyAPIGatewayID   = "00000000-0000-0000-0000-000000000008"
+	ACLTemplatedPolicyNomadClientID  = "00000000-0000-0000-0000-000000000009"
 	ACLTemplatedPolicyAllowServiceID = "00000000-0000-0000-0000-000000000010"
 	ACLTemplatedPolicyAllowPathID    = "00000000-0000-0000-0000-000000000011"
 	ACLTemplatedPolicyEnableAgentID  = "00000000-0000-0000-0000-000000000012"
 
-	ACLTemplatedPolicyServiceDescription     = "Gives the token or role permissions to register a service and discover services in the Consul catalog. It also gives the specified service's sidecar proxy the permission to discover and route traffic to other services."
-	ACLTemplatedPolicyNodeDescription        = "Gives the token or role permissions for a register an agent/node into the catalog. A node is typically a consul agent but can also be a physical server, cloud instance or a container."
-	ACLTemplatedPolicyDNSDescription         = "Gives the token or role permissions for the Consul DNS to query services in the network."
-	ACLTemplatedPolicyNomadServerDescription = "Gives the token or role permissions required for integration with a nomad server."
-	ACLTemplatedPolicyAPIGatewayDescription  = "Gives the token or role permissions for a Consul api gateway"
-	ACLTemplatedPolicyNomadClientDescription = "Gives the token or role permissions required for integration with a nomad client."
+	ACLTemplatedPolicyServiceDescription      = "Gives the token or role permissions to register a service and discover services in the Consul catalog. It also gives the specified service's sidecar proxy the permission to discover and route traffic to other services."
+	ACLTemplatedPolicyNodeDescription         = "Gives the token or role permissions for a register an agent/node into the catalog. A node is typically a consul agent but can also be a physical server, cloud instance or a container."
+	ACLTemplatedPolicyDNSDescription          = "Gives the token or role permissions for the Consul DNS to query services in the network."
+	ACLTemplatedPolicyNomadServerDescription  = "Gives the token or role permissions required for integration with a nomad server."
+	ACLTemplatedPolicyAPIGatewayDescription   = "Gives the token or role permissions for a Consul api gateway"
+	ACLTemplatedPolicyNomadClientDescription  = "Gives the token or role permissions required for integration with a nomad client."
 	ACLTemplatedPolicyAllowServiceDescription = "Grants write access to a service prefix"
 	ACLTemplatedPolicyAllowPathDescription    = "Grants write access to a key prefix"
 	ACLTemplatedPolicyEnableAgentDescription  = "Grants write access to agent and node prefixes"

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -717,9 +717,16 @@ func TestAPI_ClientTLSOptions(t *testing.T) {
 
 		// Should fail
 		_, err = client.Agent().Self()
-		// Check for one of the possible cert error messages
+		if err == nil {
+			t.Fatal("expected tls certificate error, but got nil")
+		}
+		// Check for one of the possible cert error messages. A TLS server can also
+		// close the connection while rejecting a missing client certificate.
 		// See https://cs.opensource.google/go/go/+/62a994837a57a7d0c58bb364b580a389488446c9
-		if err == nil || (!strings.Contains(err.Error(), "tls: bad certificate") && !strings.Contains(err.Error(), "tls: certificate required")) {
+		if !strings.Contains(err.Error(), "tls: bad certificate") &&
+			!strings.Contains(err.Error(), "tls: certificate required") &&
+			!strings.Contains(err.Error(), "connection reset by peer") &&
+			!strings.Contains(err.Error(), "broken pipe") {
 			t.Fatalf("expected tls certificate error, but got '%v'", err)
 		}
 	})


### PR DESCRIPTION
## Summary
- Fix the gofmt/staticcheck issues exposed after the public fork go-tests workflow was repaired in https://github.com/criteo-forks/consul/pull/265.
- Stabilize TestAPI_ClientTLSOptions for OS-level server-close errors during missing-client-certificate rejection.

## Details
- Lint provenance: the failing lines come from the public fork patch stack in https://github.com/criteo-forks/consul/pull/263 and https://github.com/criteo-forks/consul/pull/264.
- TLS provenance: the same assertion failure reproduces on upstream https://github.com/hashicorp/consul/tree/v1.22.3, so this is a latent upstream test expectation issue rather than a Criteo feature PR regression.

## Validation
- `env GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache GOPATH=/tmp/consul-gopath GOCACHE=/tmp/consul-go-cache GOMODCACHE=/tmp/consul-gopath/pkg/mod golangci-lint run ./agent/consul ./agent/structs`
- `env PATH=/home/manu/git/consul-criteo/bin:$PATH GOPATH=/tmp/consul-gopath GOCACHE=/tmp/consul-go-cache GOMODCACHE=/tmp/consul-gopath/pkg/mod go test . -run '^TestAPI_ClientTLSOptions$' -count=10`