### PR TITLE
Add option to hide datacenters from /catalog/datacenters endpoint

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1354,6 +1354,7 @@ func newConsulConfig(runtimeCfg *config.RuntimeConfig, logger hclog.Logger) (*co
 	// todo(fs): or is there a reason to keep it like that?
 	cfg.Datacenter = runtimeCfg.Datacenter
 	cfg.PrimaryDatacenter = runtimeCfg.PrimaryDatacenter
+	cfg.HiddenDatacenters = runtimeCfg.HiddenDatacenters
 	cfg.DataDir = runtimeCfg.DataDir
 	cfg.NodeName = runtimeCfg.NodeName
 	cfg.ACLResolverSettings = runtimeCfg.ACLResolverSettings

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1076,6 +1076,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		PeeringTestAllowPeerRegistrations: boolValWithDefault(c.Peering.TestAllowPeerRegistrations, false),
 		PidFile:                           stringVal(c.PidFile),
 		PrimaryDatacenter:                 primaryDatacenter,
+		HiddenDatacenters:                 c.HiddenDatacenters,
 		PrimaryGateways:                   b.expandAllOptionalAddrs("primary_gateways", c.PrimaryGateways),
 		PrimaryGatewaysInterval:           b.durationVal("primary_gateways_interval", c.PrimaryGatewaysInterval),
 		RPCAdvertiseAddr:                  rpcAdvertiseAddr,

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -190,6 +190,7 @@ type Config struct {
 	GossipLAN                        GossipLANConfig     `mapstructure:"gossip_lan" json:"-"`
 	GossipWAN                        GossipWANConfig     `mapstructure:"gossip_wan" json:"-"`
 	HTTPConfig                       HTTPConfig          `mapstructure:"http_config" json:"-"`
+	HiddenDatacenters                []string            `mapstructure:"hidden_datacenters" json:"hidden_datacenters,omitempty"`
 	LeaveOnTerm                      *bool               `mapstructure:"leave_on_terminate" json:"leave_on_terminate,omitempty"`
 	LicensePath                      *string             `mapstructure:"license_path" json:"license_path,omitempty"`
 	Limits                           Limits              `mapstructure:"limits" json:"-"`

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -79,6 +79,7 @@ func AddFlags(fs *flag.FlagSet, f *LoadOpts) {
 	add(&f.FlagValues.RaftProtocol, "raft-protocol", "Sets the Raft protocol version. Defaults to latest.")
 	add(&f.FlagValues.DNSRecursors, "recursor", "Address of an upstream DNS server. Can be specified multiple times.")
 	add(&f.FlagValues.PrimaryGateways, "primary-gateway", "Address of a mesh gateway in the primary datacenter to use to bootstrap WAN federation at start time with retries enabled. Can be specified multiple times.")
+	add(&f.FlagValues.HiddenDatacenters, "hidden-datacenter", "Datacenter to hide from the /v1/catalog/datacenters endpoint response. Can be specified multiple times.")
 	add(&f.FlagValues.RejoinAfterLeave, "rejoin", "Ignores a previous leave and attempts to rejoin the cluster.")
 	add(&f.FlagValues.AutoReloadConfig, "auto-reload-config", "Watches config files for changes and auto reloads the files when modified.")
 	add(&f.FlagValues.RetryJoinIntervalLAN, "retry-interval", "Time to wait between join attempts.")

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -902,6 +902,15 @@ type RuntimeConfig struct {
 	// hcl: primary_datacenter = string
 	PrimaryDatacenter string
 
+	// HiddenDatacenters is a list of datacenter names that should be omitted
+	// from the response of the /v1/catalog/datacenters endpoint. The
+	// datacenters remain fully federated and routable; they are only hidden
+	// from that listing.
+	//
+	// hcl: hidden_datacenters = []string
+	// flag: -hidden-datacenter string -hidden-datacenter string
+	HiddenDatacenters []string
+
 	// PrimaryGateways is a list of addresses and/or go-discover expressions to
 	// discovery the mesh gateways in the primary datacenter. See
 	// https://developer.hashicorp.com/docs/agent/config/cli-flags#cloud-auto-joining for

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -231,6 +231,7 @@
     "HTTPSHandshakeTimeout": "0s",
     "HTTPSPort": 0,
     "HTTPUseCache": false,
+    "HiddenDatacenters": [],
     "KVMaxValueSize": 1234567800000000,
     "LeaveDrainTime": "0s",
     "LeaveOnTerm": false,

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -531,6 +531,23 @@ func (c *Catalog) ListDatacenters(args *structs.DatacentersRequest, reply *[]str
 		dcs = []string{c.srv.config.Datacenter}
 	}
 
+	// Omit any datacenters the operator has configured to hide from this
+	// listing. The datacenters remain federated and routable; they are only
+	// filtered out of this endpoint's response.
+	if len(c.srv.config.HiddenDatacenters) > 0 {
+		hidden := make(map[string]struct{}, len(c.srv.config.HiddenDatacenters))
+		for _, dc := range c.srv.config.HiddenDatacenters {
+			hidden[dc] = struct{}{}
+		}
+		filtered := dcs[:0]
+		for _, dc := range dcs {
+			if _, skip := hidden[dc]; !skip {
+				filtered = append(filtered, dc)
+			}
+		}
+		dcs = filtered
+	}
+
 	*reply = dcs
 	return nil
 }

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -874,6 +874,50 @@ func TestCatalog_ListDatacenters_DistanceSort(t *testing.T) {
 	}
 }
 
+func TestCatalog_ListDatacenters_HiddenDatacenters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.Bootstrap = true
+		// dc2 must not appear in the endpoint response, while dc1 and dc3 do.
+		c.HiddenDatacenters = []string{"dc2"}
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	dir2, s2 := testServerDC(t, "dc2")
+	defer os.RemoveAll(dir2)
+	defer s2.Shutdown()
+
+	dir3, s3 := testServerDC(t, "dc3")
+	defer os.RemoveAll(dir3)
+	defer s3.Shutdown()
+
+	// Try to join
+	joinWAN(t, s2, s1)
+	joinWAN(t, s3, s1)
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	// Wait until all three datacenters are known to the WAN router, then
+	// confirm the hidden one is filtered out of the response.
+	retry.Run(t, func(r *retry.R) {
+		dcs, err := s1.router.GetDatacentersByDistance()
+		require.NoError(r, err)
+		require.Len(r, dcs, 3)
+
+		var out []string
+		require.NoError(r, msgpackrpc.CallWithCodec(codec, "Catalog.ListDatacenters", struct{}{}, &out))
+		require.ElementsMatch(r, []string{"dc1", "dc3"}, out)
+		require.NotContains(r, out, "dc2")
+	})
+}
+
 func TestCatalog_ListNodes(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -94,6 +94,12 @@ type Config struct {
 	// and Connect.
 	PrimaryDatacenter string
 
+	// HiddenDatacenters is a list of datacenter names that are omitted from the
+	// response of the Catalog.ListDatacenters RPC (and therefore the
+	// /v1/catalog/datacenters HTTP endpoint). The datacenters remain fully
+	// federated and routable; they are only hidden from that listing.
+	HiddenDatacenters []string
+
 	// DataDir is the directory to store our state in.
 	DataDir string
 


### PR DESCRIPTION
In some cases, like when boostrapping a new dc, one could need to hide a specific datacenters from the /catalog/datacenters endpoint.

Add option to support this, from command line or config options

```
consul agent ... -hidden-datacenter dc2 -hidden-datacenter dc3
```